### PR TITLE
Get Git to ignore .pth files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Ignore all pycache files
 **/__pycache__
 
+# Ignore all .pth files
+*.pth
+
 # .idea folder
 .idea/


### PR DESCRIPTION
Actor/critic networks are stored as .pth files, but ideally, these should not end up in the repository.