### PR TITLE
line break correctly

### DIFF
--- a/tutorial_LunarLanderContinuous_v2.ipynb
+++ b/tutorial_LunarLanderContinuous_v2.ipynb
@@ -129,9 +129,9 @@
   {
    "cell_type": "code",
    "source": [
-    "import gym",
-    "from elegantrl.agents.agent import AgentModSAC",
-    "from elegantrl.train.config import get_gym_env_args, Arguments",
+    "import gym\n",
+    "from elegantrl.agents.agent import AgentModSAC\n",
+    "from elegantrl.train.config import get_gym_env_args, Arguments\n",
     "from elegantrl.train.run import *\n",
     "\n",
     "gym.logger.set_level(40) # Block warning"


### PR DESCRIPTION
https://github.com/AI4Finance-Foundation/ElegantRL/blob/master/tutorial_LunarLanderContinuous_v2.ipynb  
![image](https://user-images.githubusercontent.com/30254428/158754017-fe881f48-ecd7-4e50-9be1-732447462475.png)
These lines in tutorial_LunarLanderContinuous_v2.ipynb  seem to forget the line break