### PR TITLE
add num_layer hyperparameter

### DIFF
--- a/elegantrl/train/config.py
+++ b/elegantrl/train/config.py
@@ -36,7 +36,7 @@ class Arguments:
         self.agent = agent  # DRL algorithm
         self.net_dim = 2**7  # the network width
         self.layer_num = (
-            2  # layer number of MLP (Multi-layer perception, `assert layer_num>=2`)
+            3  # layer number of MLP (Multi-layer perception, `assert layer_num>=2`)
         )
         self.if_off_policy = (
             self.get_if_off_policy()

--- a/examples/demo_DQN_Dueling_Double_DQN.py
+++ b/examples/demo_DQN_Dueling_Double_DQN.py
@@ -4,15 +4,18 @@ import gym
 from elegantrl.train.run import train_and_evaluate, train_and_evaluate_mp
 from elegantrl.train.config import Arguments
 from elegantrl.agents.AgentDQN import AgentDQN
-from elegantrl.agents.AgentDuelingDQN import AgentDuelingDQN
+# from elegantrl.agents.AgentDuelingDQN import AgentDuelingDQN
 from elegantrl.agents.AgentDoubleDQN import AgentDoubleDQN
-from elegantrl.agents.AgentDuelingDoubleDQN import AgentDuelingDoubleDQN
+
+
+# from elegantrl.agents.AgentDuelingDoubleDQN import AgentDuelingDoubleDQN
 
 
 def demo_discrete_action_off_policy(gpu_id):
     env_name = ['CartPole-v0',
-                'LunarLander-v2', ][1]
-    agent_class = [AgentDQN, AgentDuelingDQN, AgentDoubleDQN, AgentDuelingDoubleDQN][3]
+                'LunarLander-v2', ][0]
+    # agent_class = [AgentDQN, AgentDuelingDQN, AgentDoubleDQN, AgentDuelingDoubleDQN][3]
+    agent_class = [AgentDQN, AgentDoubleDQN][1]
 
     if env_name == 'CartPole-v0':
         """


### PR DESCRIPTION
https://github.com/AI4Finance-Foundation/ElegantRL/issues/140

When creating a neural network, we can specify the network width, but we can't set the number of layers, and I want to add the hyperparameter `num_layer`. To be compatible with the previous code, the `num_layer ` is set to 3 by default.

创建神经网络时，我们可以指定网络宽度，但无法指定网络层数，我想要为网络增加 num_layer 这个超参数。为了兼容以前的代码，num_layer 这个超参数被默认设置为3.