### PR TITLE
Update AgentPPO.py

### DIFF
--- a/elegantrl/agents/AgentPPO.py
+++ b/elegantrl/agents/AgentPPO.py
@@ -180,8 +180,8 @@ class AgentPPO(AgentBase):
 
             obj_critics += obj_critic.item()
             obj_actors += obj_actor.item()
-        a_std_log = getattr(self.act, 'a_std_log', torch.zeros(1)).mean()
-        return obj_critics / update_times, obj_actors / update_times, a_std_log.item()
+        action_std = getattr(self.act, 'action_std_log', torch.zeros(1)).exp().mean()
+        return obj_critics / update_times, obj_actors / update_times, action_std.item()
 
     def get_reward_sum_raw(
             self, buf_len, buf_reward, buf_mask, buf_value


### PR DESCRIPTION
In `net.py`, the attribute name of `ActorPPO` is `action_std_log`, not `a_std_log`. This will fix the problem that in the curve plot the **std error**(which is named `6`) will always be 0. Another proposal is that plot std error rather than std_log, as `std error` is easier to understand for us than `std_log`.