### PR TITLE
💚 Add Unit tests for elegantrl.agents

### DIFF
--- a/elegantrl/agents/base.py
+++ b/elegantrl/agents/base.py
@@ -1,6 +1,6 @@
 import os
 import torch
-from typing import Tuple
+from typing import Tuple, Union
 from torch import Tensor
 from torch.nn.utils import clip_grad_norm_
 
@@ -24,7 +24,6 @@ class AgentBase:
         self.gamma = args.gamma  # discount factor of future rewards
         self.num_envs = args.num_envs  # the number of sub envs in vectorized env. `num_envs=1` in single env.
         self.batch_size = args.batch_size  # num of transitions sampled from replay buffer.
-        self.if_discrete = args.if_discrete  # if the action space of env is discrete or continuous
         self.repeat_times = args.repeat_times  # repeatedly update network using ReplayBuffer
         self.reward_scale = args.reward_scale  # an approximate target reward usually be closed to 256
         self.learning_rate = args.learning_rate  # the learning rate for network updating
@@ -145,10 +144,10 @@ class AgentBase:
         undones = 1.0 - dones.type(torch.float32)
         return states, actions, rewards, undones
 
-    def update_net(self, buffer: ReplayBuffer) -> Tuple[float, ...]:
-        obj_critic = 0.0
-        obj_actor = 0.0
-        assert isinstance(buffer, ReplayBuffer) or isinstance(buffer, list)
+    def update_net(self, buffer: Union[ReplayBuffer, tuple]) -> Tuple[float, ...]:
+        obj_critic = 0.0  # criterion(q_value, q_label).mean().item()
+        obj_actor = 0.0  # q_value.mean().item()
+        assert isinstance(buffer, ReplayBuffer) or isinstance(buffer, tuple)
         assert isinstance(self.batch_size, int)
         assert isinstance(self.repeat_times, int)
         assert isinstance(self.reward_scale, float)

--- a/elegantrl/agents/ddpg.py
+++ b/elegantrl/agents/ddpg.py
@@ -65,7 +65,7 @@ class AgentDDPG(AgentBase):
         with torch.no_grad():
             state, action, reward, undone, next_s = buffer.sample(batch_size)
             next_a = self.act_target(next_s)  # policy noise
-            next_q = self.cri_target.get_q_min(next_s, next_a)  # twin critics
+            next_q = self.cri_target(next_s, next_a)  # twin critics
             q_label = reward + undone * self.gamma * next_q
 
         q_value = self.cri(state, action)

--- a/elegantrl/agents/sac.py
+++ b/elegantrl/agents/sac.py
@@ -78,9 +78,9 @@ class AgentSAC(AgentBase):
 
 
 class AgentModSAC(AgentSAC):  # Modified SAC using reliable_lambda and Two Time-scale Update Rule
-    def __init__(self, net_dim, state_dim, action_dim, gpu_id=0, args=None):
+    def __init__(self, net_dims: [int], state_dim: int, action_dim: int, gpu_id: int = 0, args: Config = Config()):
         self.act_class = getattr(self, "act_class", ActorFixSAC)
-        super().__init__(net_dim, state_dim, action_dim, gpu_id, args)
+        super().__init__(net_dims=net_dims, state_dim=state_dim, action_dim=action_dim, gpu_id=gpu_id, args=args)
         self.obj_c = 1.0  # for reliable_lambda
 
     def update_net(self, buffer: ReplayBuffer) -> Tuple[float, ...]:

--- a/elegantrl/train/__init__.py
+++ b/elegantrl/train/__init__.py
@@ -1,4 +1,4 @@
-from run import train_agent, train_agent_multiprocessing
-from config import Config, build_env, get_gym_env_args
-from evaluator import Evaluator
-from replay_buffer import ReplayBuffer
+from elegantrl.train.run import train_agent, train_agent_multiprocessing
+from elegantrl.train.config import Config, build_env, get_gym_env_args
+from elegantrl.train.evaluator import Evaluator
+from elegantrl.train.replay_buffer import ReplayBuffer

--- a/examples/demo_A2C_PPO.py
+++ b/examples/demo_A2C_PPO.py
@@ -683,8 +683,8 @@ def demo_load_pendulum_and_render():
 
     '''evaluate'''
     eval_times = 2 ** 7
-    from elegantrl.train.evaluator import get_rewards_and_step
-    rewards_step_list = [get_rewards_and_step(env, act) for _ in range(eval_times)]
+    from elegantrl.train.evaluator import get_rewards_and_steps
+    rewards_step_list = [get_rewards_and_steps(env, act) for _ in range(eval_times)]
     rewards_step_ten = torch.tensor(rewards_step_list)
     print(f"\n| average cumulative_returns {rewards_step_ten[:, 0].mean().item():9.3f}"
           f"\n| average      episode steps {rewards_step_ten[:, 1].mean().item():9.3f}")

--- a/unit_tests/check_agents.py
+++ b/unit_tests/check_agents.py
@@ -1,0 +1,318 @@
+import gym
+import torch
+from copy import deepcopy
+from typing import Tuple
+from torch import Tensor
+
+from elegantrl.train.config import Config, build_env
+from elegantrl.train.replay_buffer import ReplayBuffer
+from elegantrl.envs.CustomGymEnv import PendulumEnv
+
+
+def _check_buffer_items_for_off_policy(
+        buffer_items: Tuple[Tensor, ...], if_discrete: bool,
+        horizon_len: int, num_envs: int, state_dim: int, action_dim: int
+):
+    states, actions, rewards, undones = buffer_items
+
+    assert states.shape == (horizon_len, num_envs, state_dim)
+    assert states.dtype in {torch.float, torch.int}
+
+    if if_discrete:
+        actions_shape = (horizon_len, num_envs, 1)
+        actions_dtypes = {torch.int, torch.long}
+    else:
+        actions_shape = (horizon_len, num_envs, action_dim)
+        actions_dtypes = {torch.float, }
+    assert actions.shape == actions_shape
+    assert actions.dtype in actions_dtypes
+
+    assert rewards.shape == (horizon_len, num_envs)
+    assert rewards.dtype == torch.float
+
+    assert undones.shape == (horizon_len, num_envs)
+    assert undones.dtype == torch.float  # undones is float, instead of int
+    assert set(undones.squeeze(1).cpu().data.tolist()).issubset({0.0, 1.0})  # undones in {0.0, 1.0}
+
+
+def _check_buffer_items_for_ppo_style(
+        buffer_items: Tuple[Tensor, ...], if_discrete: bool,
+        horizon_len: int, num_envs: int, state_dim: int, action_dim: int
+):
+    states, actions, logprobs, rewards, undones = buffer_items
+
+    assert states.shape == (horizon_len, num_envs, state_dim)
+    assert states.dtype in {torch.float, torch.int}
+
+    if if_discrete:
+        actions_shape = (horizon_len, num_envs, 1)
+        actions_dtypes = {torch.int, torch.long}
+    else:
+        actions_shape = (horizon_len, num_envs, action_dim)
+        actions_dtypes = {torch.float, }
+
+    assert actions.shape == actions_shape
+    assert actions.dtype in actions_dtypes
+
+    assert logprobs.shape == (horizon_len, num_envs)
+    assert logprobs.dtype == torch.float
+
+    assert rewards.shape == (horizon_len, num_envs)
+    assert rewards.dtype == torch.float
+
+    assert undones.shape == (horizon_len, num_envs)
+    assert undones.dtype == torch.float  # undones is float, instead of int
+    assert set(undones.squeeze(1).cpu().data.tolist()).issubset({0.0, 1.0})  # undones in {0.0, 1.0}
+
+
+def check_agent_base(state_dim=4, action_dim=2, batch_size=3, net_dims=(64, 32), gpu_id=0):
+    print("\n| check_agent_base()")
+
+    device = torch.device(f"cuda:{gpu_id}" if (torch.cuda.is_available() and (gpu_id >= 0)) else "cpu")
+    state = torch.rand(size=(batch_size, state_dim), dtype=torch.float32, device=device).detach()
+    action = torch.rand(size=(batch_size, action_dim), dtype=torch.float32, device=device).detach()
+
+    '''check AgentBase.__init__'''
+    from elegantrl.agents.base import AgentBase
+    from elegantrl.agents.ddpg import AgentDDPG
+    agent = AgentDDPG(net_dims, state_dim, action_dim, gpu_id=gpu_id, args=Config())
+    AgentBase.__init__(agent, net_dims, state_dim, action_dim, gpu_id=gpu_id, args=Config())
+
+    '''check AgentBase attribution'''
+    assert hasattr(agent, 'explore_env')
+    assert hasattr(agent, 'explore_one_env')
+    assert hasattr(agent, 'explore_vec_env')
+
+    assert hasattr(agent, 'update_net')
+    assert hasattr(agent, 'get_obj_critic')
+    assert hasattr(agent, 'get_obj_critic_raw')
+    assert hasattr(agent, 'get_obj_critic_per')
+
+    assert hasattr(agent, 'update_avg_std_for_normalization')
+    assert hasattr(agent, 'get_returns')
+    assert hasattr(agent.act, 'state_avg')
+    assert hasattr(agent.act, 'state_std')
+    assert hasattr(agent.cri, 'state_avg')
+    assert hasattr(agent.cri, 'state_std')
+    assert hasattr(agent.cri, 'value_avg')
+    assert hasattr(agent.cri, 'value_std')
+
+    '''check agent.optimizer'''
+    action_grad = agent.act(state)
+    q_value = agent.cri(state, action_grad)
+    obj_act = -q_value.mean()
+    assert agent.optimizer_update(agent.act_optimizer, obj_act) is None
+    q_value = agent.cri(state, action)
+    obj_cri = agent.criterion(q_value, torch.zeros_like(q_value).detach()).mean()
+    assert agent.optimizer_update(agent.cri_optimizer, obj_cri) is None
+
+    current_net = agent.cri
+    target_net = deepcopy(agent.cri)
+    assert agent.soft_update(target_net=target_net, current_net=current_net, tau=3e-5) is None
+
+
+def check_agent_dqn_style(batch_size=3, horizon_len=16, net_dims=(64, 32), gpu_id=0):
+    print("\n| check_agent_dqn()")
+
+    env_args = {'env_name': 'CartPole-v1', 'state_dim': 4, 'action_dim': 2, 'if_discrete': True}
+    env = build_env(env_class=gym.make, env_args=env_args)
+    num_envs = env_args['num_envs']
+    state_dim = env_args['state_dim']
+    action_dim = env_args['action_dim']
+    if_discrete = env_args['if_discrete']
+
+    '''init agent'''
+    from elegantrl.agents.dqn import AgentDQN, AgentDuelingDQN, AgentDoubleDQN, AgentD3QN
+    for agent_class in (AgentDQN, AgentDuelingDQN, AgentDoubleDQN, AgentD3QN):
+        print(f"| agent_class = {agent_class.__name__}")
+
+        buffer = ReplayBuffer(gpu_id=gpu_id, max_size=int(1e4), state_dim=state_dim, action_dim=1, )
+        args = Config()
+        args.batch_size = batch_size
+        agent = agent_class(net_dims=net_dims, state_dim=state_dim, action_dim=action_dim, gpu_id=gpu_id, args=args)
+        agent.last_state = torch.tensor(env.reset(), dtype=torch.float32, device=agent.device)
+        assert isinstance(agent.last_state, Tensor)
+
+        '''check for agent.explore_env'''
+        for if_random in (True, False):
+            print(f"| if_random = {if_random}")
+
+            buffer_items = agent.explore_env(env=env, horizon_len=horizon_len, if_random=if_random)
+            _check_buffer_items_for_off_policy(
+                buffer_items=buffer_items, if_discrete=if_discrete,
+                horizon_len=horizon_len, num_envs=num_envs,
+                state_dim=state_dim, action_dim=action_dim
+            )
+            buffer.update(buffer_items)
+
+        '''check for agent.update_net'''
+        buffer.update(buffer_items)
+        obj_critic, q_value = agent.get_obj_critic(buffer=buffer, batch_size=batch_size)
+        assert obj_critic.shape == ()
+        assert q_value.shape == (batch_size,)
+        assert q_value.dtype == torch.float32
+
+        logging_tuple = agent.update_net(buffer=buffer)
+        assert isinstance(logging_tuple, tuple)
+        assert any([isinstance(item, float) for item in logging_tuple])
+        assert len(logging_tuple) >= 2
+
+
+def check_agent_ddpg_style(batch_size=3, horizon_len=16, net_dims=(64, 32), gpu_id=0):
+    print("\n| check_agent_ddpg_style()")
+
+    env_args = {'env_name': 'Pendulum', 'state_dim': 3, 'action_dim': 1, 'if_discrete': False}
+    env = build_env(env_class=PendulumEnv, env_args=env_args)
+    num_envs = env_args['num_envs']
+    state_dim = env_args['state_dim']
+    action_dim = env_args['action_dim']
+    if_discrete = env_args['if_discrete']
+
+    '''init agent'''
+    from elegantrl.agents.ddpg import AgentDDPG
+    from elegantrl.agents.td3 import AgentTD3
+    from elegantrl.agents.sac import AgentSAC, AgentModSAC
+    for agent_class in (AgentDDPG, AgentTD3, AgentSAC, AgentModSAC):
+        print(f"| agent_class = {agent_class.__name__}")
+
+        buffer = ReplayBuffer(gpu_id=gpu_id, max_size=int(1e4), state_dim=state_dim, action_dim=action_dim, )
+        args = Config()
+        args.batch_size = batch_size
+        agent = agent_class(net_dims=net_dims, state_dim=state_dim, action_dim=action_dim, gpu_id=gpu_id, args=args)
+        agent.last_state = torch.tensor(env.reset(), dtype=torch.float32, device=agent.device)
+        assert isinstance(agent.last_state, Tensor)
+
+        '''check for agent.explore_env'''
+        for if_random in (True, False):
+            print(f"| if_random = {if_random}")
+
+            buffer_items = agent.explore_env(env=env, horizon_len=horizon_len, if_random=if_random)
+            _check_buffer_items_for_off_policy(
+                buffer_items=buffer_items, if_discrete=if_discrete,
+                horizon_len=horizon_len, num_envs=num_envs,
+                state_dim=state_dim, action_dim=action_dim
+            )
+            buffer.update(buffer_items)
+
+        '''check for agent.update_net'''
+        buffer.update(buffer_items)
+        obj_critic, state = agent.get_obj_critic(buffer=buffer, batch_size=batch_size)
+        assert obj_critic.shape == ()
+        assert state.shape == (batch_size, state_dim)
+        assert state.dtype in {torch.float, torch.int}
+
+        logging_tuple = agent.update_net(buffer=buffer)
+        assert isinstance(logging_tuple, tuple)
+        assert any([isinstance(item, float) for item in logging_tuple])
+        assert len(logging_tuple) >= 2
+
+
+def check_agent_ppo_style(batch_size=3, horizon_len=16, net_dims=(64, 32), gpu_id=0):
+    print("\n| check_agent_ddpg_style()")
+
+    env_args = {'env_name': 'Pendulum', 'state_dim': 3, 'action_dim': 1, 'if_discrete': False}
+    env = build_env(env_class=PendulumEnv, env_args=env_args)
+    num_envs = env_args['num_envs']
+    state_dim = env_args['state_dim']
+    action_dim = env_args['action_dim']
+    if_discrete = env_args['if_discrete']
+
+    '''init agent'''
+    from elegantrl.agents.ppo import AgentPPO  # , AgentDiscretePPO
+    from elegantrl.agents.a2c import AgentA2C  # , AgentDiscreteA2C
+    for agent_class in (AgentPPO, AgentA2C):
+        print(f"| agent_class = {agent_class.__name__}")
+
+        args = Config()
+        args.batch_size = batch_size
+        agent = agent_class(net_dims=net_dims, state_dim=state_dim, action_dim=action_dim, gpu_id=gpu_id, args=args)
+        agent.last_state = torch.tensor(env.reset(), dtype=torch.float32, device=agent.device)
+        assert isinstance(agent.last_state, Tensor)
+
+        convert = agent.act.convert_action_for_env
+        action = torch.rand(size=(batch_size, action_dim), dtype=torch.float32).detach() * 6 - 3
+        assert torch.any((action < -1.0) | (+1.0 < action))
+        action = convert(action)
+        assert torch.any((-1.0 <= action) & (action <= +1.0))
+
+        '''check for agent.explore_env'''
+        buffer_items = agent.explore_env(env=env, horizon_len=horizon_len)
+        _check_buffer_items_for_ppo_style(
+            buffer_items=buffer_items, if_discrete=if_discrete,
+            horizon_len=horizon_len, num_envs=num_envs,
+            state_dim=state_dim, action_dim=action_dim,
+        )
+
+        '''check for agent.update_net'''
+        states, actions, logprobs, rewards, undones = buffer_items
+
+        values = agent.cri(states).squeeze(1)
+        assert values.shape == (horizon_len, num_envs)
+
+        advantages = agent.get_advantages(rewards, undones, values)
+        assert advantages.shape == (horizon_len, num_envs)
+
+        logging_tuple = agent.update_net(buffer=buffer_items)
+        assert isinstance(logging_tuple, tuple)
+        assert any([isinstance(item, float) for item in logging_tuple])
+        assert len(logging_tuple) >= 2
+
+
+def check_agent_ppo_discrete_style(batch_size=3, horizon_len=16, net_dims=(64, 32), gpu_id=0):  # FIXME
+    print("\n| check_agent_ppo_discrete_style()")
+
+    env_args = {'env_name': 'CartPole-v1', 'state_dim': 4, 'action_dim': 2, 'if_discrete': True}
+    env = build_env(env_class=gym.make, env_args=env_args)
+    num_envs = env_args['num_envs']
+    state_dim = env_args['state_dim']
+    action_dim = env_args['action_dim']
+    if_discrete = env_args['if_discrete']
+
+    '''init agent'''
+    from elegantrl.agents.ppo import AgentDiscretePPO
+    from elegantrl.agents.a2c import AgentDiscreteA2C
+    for agent_class in (AgentDiscretePPO, AgentDiscreteA2C):
+        print(f"| agent_class = {agent_class.__name__}")
+
+        args = Config()
+        args.batch_size = batch_size
+        agent = agent_class(net_dims=net_dims, state_dim=state_dim, action_dim=action_dim, gpu_id=gpu_id, args=args)
+        agent.last_state = torch.tensor(env.reset(), dtype=torch.float32, device=agent.device)
+        assert isinstance(agent.last_state, Tensor)
+
+        convert = agent.act.convert_action_for_env
+        action = torch.rand(size=(batch_size, action_dim), dtype=torch.float32).detach() * 6 - 3
+        assert torch.any((action < -1.0) | (+1.0 < action))
+        action = convert(action)
+        assert torch.any((-1.0 <= action) & (action <= +1.0))
+
+        '''check for agent.explore_env'''
+        buffer_items = agent.explore_env(env=env, horizon_len=horizon_len)
+        _check_buffer_items_for_ppo_style(
+            buffer_items=buffer_items, if_discrete=if_discrete,
+            horizon_len=horizon_len, num_envs=num_envs,
+            state_dim=state_dim, action_dim=action_dim,
+        )
+
+        '''check for agent.update_net'''
+        states, actions, logprobs, rewards, undones = buffer_items
+
+        values = agent.cri(states).squeeze(1)
+        assert values.shape == (horizon_len, num_envs)
+
+        advantages = agent.get_advantages(rewards, undones, values)
+        assert advantages.shape == (horizon_len, num_envs)
+
+        logging_tuple = agent.update_net(buffer=buffer_items)
+        assert isinstance(logging_tuple, tuple)
+        assert any([isinstance(item, float) for item in logging_tuple])
+        assert len(logging_tuple) >= 2
+
+
+if __name__ == '__main__':
+    check_agent_base()
+    check_agent_dqn_style()
+    check_agent_ddpg_style()
+    check_agent_ppo_style()
+    # check_agent_ppo_discrete_style()
+    print('| Finish checking.')


### PR DESCRIPTION
Following the `helloworld/unit_tests`, we add `elegantrl/unit_tests`.

Run `./unit_tests/check_agents.py` directly. 

Then the output of this unit test is:
```
| check_agent_base()

| check_agent_dqn()
| agent_class = AgentDQN
| if_random = True
| if_random = False
| agent_class = AgentDuelingDQN
| if_random = True
| if_random = False
| agent_class = AgentDoubleDQN
| if_random = True
| if_random = False
| agent_class = AgentD3QN
| if_random = True
| if_random = False

| check_agent_ddpg_style()
| agent_class = AgentDDPG
| if_random = True
| if_random = False
| agent_class = AgentTD3
| if_random = True
| if_random = False
| agent_class = AgentSAC
| if_random = True
| if_random = False
| agent_class = AgentModSAC
| if_random = True
| if_random = False

| check_agent_ddpg_style()
| agent_class = AgentPPO
| agent_class = AgentA2C
| AgentA2C: A2C or A3C is worse than PPO in any case. We provide AgentA2C code just for teaching.
| Without TrustRegion, A2C needs special hyper-parameters, such as smaller repeat_times.
| Finish checking.
```