### PR TITLE
Fix bug PER moudle for mp and vec env

### DIFF
--- a/elegantrl/agents/AgentBase.py
+++ b/elegantrl/agents/AgentBase.py
@@ -154,30 +154,32 @@ class AgentBase:
 
     def get_obj_critic_raw(self, buffer: ReplayBuffer, batch_size: int) -> Tuple[Tensor, Tensor]:
         with torch.no_grad():
-            state, action, reward, undone, next_s = buffer.sample(batch_size)
-            next_a = self.act_target(next_s)  # policy noise
-            next_q = self.cri_target(next_s, next_a)  # twin critics
-            q_label = reward + undone * self.gamma * next_q
+            states, actions, rewards, undones, next_ss = buffer.sample(batch_size)  # next_ss: next states
+            next_as = self.act_target(next_ss)  # next actions
+            next_qs = self.cri_target(next_ss, next_as)  # next q values
+            q_labels = rewards + undones * self.gamma * next_qs
 
-        q_value = self.cri(state, action)
-        obj_critic = self.criterion(q_value, q_label)
-        return obj_critic, state
+        q_values = self.cri(states, actions)
+        obj_critic = self.criterion(q_values, q_labels)
+        return obj_critic, states
 
     def get_obj_critic_per(self, buffer: ReplayBuffer, batch_size: int) -> Tuple[Tensor, Tensor]:
         with torch.no_grad():
-            state, action, reward, undone, next_s, is_weight, is_indices = buffer.sample_for_per(batch_size)
-            next_a = self.act_target(next_s)  # policy noise
-            next_q = self.cri_target.get_q_min(next_s, next_a)  # twin critics
-            q_label = reward + undone * self.gamma * next_q
+            states, actions, rewards, undones, next_ss, is_weights, is_indices = buffer.sample_for_per(batch_size)
+            # is_weights, is_indices: important sampling `weights, indices` by Prioritized Experience Replay (PER)
 
-        q_value = self.cri(state, action)
-        td_error = self.criterion(q_value, q_label)
-        obj_critic = (td_error * is_weight).mean()
+            next_as = self.act_target(next_ss)
+            next_qs = self.cri_target(next_ss, next_as)
+            q_labels = rewards + undones * self.gamma * next_qs
 
-        buffer.td_error_update_for_per(is_indices.detach(), td_error.detach())
-        return obj_critic, state
+        q_values = self.cri(states, actions)
+        td_errors = self.criterion(q_values, q_labels)
+        obj_critic = (td_errors * is_weights).mean()
 
-    def get_returns(self, rewards: Tensor, undones: Tensor) -> Tensor:
+        buffer.td_error_update_for_per(is_indices.detach(), td_errors.detach())
+        return obj_critic, states
+
+    def get_cumulative_rewards(self, rewards: Tensor, undones: Tensor) -> Tensor:
         returns = torch.empty_like(rewards)
 
         masks = undones * self.gamma

--- a/elegantrl/agents/AgentDDPG.py
+++ b/elegantrl/agents/AgentDDPG.py
@@ -38,7 +38,7 @@ class AgentDDPG(AgentBase):
             states, actions, rewards, undones = buffer.add_item
             self.update_avg_std_for_normalization(
                 states=states.reshape((-1, self.state_dim)),
-                returns=self.get_returns(rewards=rewards, undones=undones).reshape((-1,))
+                returns=self.get_cumulative_rewards(rewards=rewards, undones=undones).reshape((-1,))
             )
 
         '''update network'''
@@ -62,28 +62,30 @@ class AgentDDPG(AgentBase):
 
     def get_obj_critic_raw(self, buffer: ReplayBuffer, batch_size: int) -> Tuple[Tensor, Tensor]:
         with torch.no_grad():
-            state, action, reward, undone, next_s = buffer.sample(batch_size)
-            next_a = self.act_target(next_s)  # policy noise
-            next_q = self.cri_target(next_s, next_a)  # twin critics
-            q_label = reward + undone * self.gamma * next_q
+            states, actions, rewards, undones, next_ss = buffer.sample(batch_size)  # next_ss: next states
+            next_as = self.act_target(next_ss)  # next actions
+            next_qs = self.cri_target(next_ss, next_as)  # next q_values
+            q_labels = rewards + undones * self.gamma * next_qs
 
-        q_value = self.cri(state, action)
-        obj_critic = self.criterion(q_value, q_label)
-        return obj_critic, state
+        q_values = self.cri(states, actions)
+        obj_critic = self.criterion(q_values, q_labels)
+        return obj_critic, states
 
     def get_obj_critic_per(self, buffer: ReplayBuffer, batch_size: int) -> Tuple[Tensor, Tensor]:
         with torch.no_grad():
-            state, action, reward, undone, next_s, is_weight, is_indices = buffer.sample_for_per(batch_size)
-            next_a = self.act_target(next_s)  # policy noise
-            next_q = self.cri_target.get_q_min(next_s, next_a)  # twin critics
-            q_label = reward + undone * self.gamma * next_q
+            states, actions, rewards, undones, next_ss, is_weights, is_indices = buffer.sample_for_per(batch_size)
+            # is_weights, is_indices: important sampling `weights, indices` by Prioritized Experience Replay (PER)
 
-        q_value = self.cri(state, action)
-        td_error = self.criterion(q_value, q_label)
-        obj_critic = (td_error * is_weight).mean()
+            next_as = self.act_target(next_ss)
+            next_qs = self.cri_target(next_ss, next_as)
+            q_labels = rewards + undones * self.gamma * next_qs
 
-        buffer.td_error_update_for_per(is_indices.detach(), td_error.detach())
-        return obj_critic, state
+        q_values = self.cri(states, actions)
+        td_errors = self.criterion(q_values, q_labels)
+        obj_critic = (td_errors * is_weights).mean()
+
+        buffer.td_error_update_for_per(is_indices.detach(), td_errors.detach())
+        return obj_critic, states
 
 
 class OrnsteinUhlenbeckNoise:

--- a/elegantrl/agents/AgentDQN.py
+++ b/elegantrl/agents/AgentDQN.py
@@ -49,21 +49,22 @@ class AgentDQN(AgentBase):
         rewards = torch.zeros((horizon_len, self.num_envs), dtype=torch.float32).to(self.device)
         dones = torch.zeros((horizon_len, self.num_envs), dtype=torch.bool).to(self.device)
 
-        state = self.last_state  # last_state.shape = (state_dim, ) for a single env.
+        state = self.last_state  # state.shape == (1, state_dim) for a single env.
+
         get_action = self.act.get_action
         for t in range(horizon_len):
-            action = torch.randint(self.action_dim, size=(1, 1)) if if_random \
-                else get_action(state.unsqueeze(0))  # different
+            action = torch.randint(self.action_dim, size=(1, 1)) if if_random else get_action(state)  # different
             states[t] = state
 
             ary_action = action[0, 0].detach().cpu().numpy()
             ary_state, reward, done, _ = env.step(ary_action)  # next_state
-            state = torch.as_tensor(env.reset() if done else ary_state, dtype=torch.float32, device=self.device)
+            ary_state = env.reset() if done else ary_state  # ary_state.shape == (state_dim, )
+            state = torch.as_tensor(ary_state, dtype=torch.float32, device=self.device).unsqueeze(0)
             actions[t] = action
             rewards[t] = reward
             dones[t] = done
 
-        self.last_state = state
+        self.last_state = state  # state.shape == (1, state_dim) for a single env.
 
         rewards *= self.reward_scale
         undones = 1.0 - dones.type(torch.float32)
@@ -107,6 +108,14 @@ class AgentDQN(AgentBase):
         return states, actions, rewards, undones
 
     def update_net(self, buffer: ReplayBuffer) -> Tuple[float, ...]:
+        with torch.no_grad():
+            states, actions, rewards, undones = buffer.add_item
+            self.update_avg_std_for_normalization(
+                states=states.reshape((-1, self.state_dim)),
+                returns=self.get_returns(rewards=rewards, undones=undones).reshape((-1,))
+            )
+
+        '''update network'''
         obj_critics = 0.0
         obj_actors = 0.0
 
@@ -146,17 +155,29 @@ class AgentDQN(AgentBase):
         :return: the loss of the network and Q values.
         """
         with torch.no_grad():
-            state, action, reward, undone, next_s, is_weights = buffer.sample(batch_size)
+            state, action, reward, undone, next_s, is_weight, is_indices = buffer.sample_for_per(batch_size)
 
             next_q = self.cri_target(next_s).max(dim=1, keepdim=True)[0].squeeze(1)
             q_label = reward + undone * self.gamma * next_q
 
         q_value = self.cri(state).gather(1, action.long()).squeeze(1)
         td_error = self.criterion(q_value, q_label)  # or td_error = (q_value - q_label).abs()
-        obj_critic = (td_error * is_weights).mean()
+        obj_critic = (td_error * is_weight).mean()
 
-        buffer.td_error_update(td_error.detach())
+        buffer.td_error_update_for_per(is_indices.detach(), td_error.detach())
         return obj_critic, q_value
+
+    def get_returns(self, rewards: Tensor, undones: Tensor) -> Tensor:
+        returns = torch.empty_like(rewards)
+
+        masks = undones * self.gamma
+        horizon_len = rewards.shape[0]
+
+        last_state = self.last_state
+        next_value = self.act_target(last_state).argmax(dim=1).detach()  # actor is Q Network in DQN style
+        for t in range(horizon_len - 1, -1, -1):
+            returns[t] = next_value = rewards[t] + masks[t] * next_value
+        return returns
 
 
 class AgentDoubleDQN(AgentDQN):
@@ -196,16 +217,16 @@ class AgentDoubleDQN(AgentDQN):
         :return: the loss of the network and Q values.
         """
         with torch.no_grad():
-            state, action, reward, undone, next_s, is_weights = buffer.sample(batch_size)
+            state, action, reward, undone, next_s, is_weight, is_indices = buffer.sample_for_per(batch_size)
 
             next_q = torch.min(*self.cri_target.get_q1_q2(next_s)).max(dim=1, keepdim=True)[0].squeeze(1)
             q_label = reward + undone * self.gamma * next_q
 
         q1, q2 = [qs.gather(1, action.long()).squeeze(1) for qs in self.act.get_q1_q2(state)]
         td_error = self.criterion(q1, q_label) + self.criterion(q2, q_label)
-        obj_critic = (td_error * is_weights).mean()
+        obj_critic = (td_error * is_weight).mean()
 
-        buffer.td_error_update(td_error.detach())
+        buffer.td_error_update_for_per(is_indices.detach(), td_error.detach())
         return obj_critic, q1
 
 

--- a/elegantrl/agents/AgentPPO.py
+++ b/elegantrl/agents/AgentPPO.py
@@ -67,14 +67,14 @@ class AgentPPO(AgentBase):
 
             ary_action = convert(action[0]).detach().cpu().numpy()
             ary_state, reward, done, _ = env.step(ary_action)  # next_state
-            state = torch.as_tensor(env.reset() if done else ary_state,
-                                    dtype=torch.float32, device=self.device).unsqueeze(0)
+            ary_state = env.reset() if done else ary_state  # ary_state.shape == (state_dim, )
+            state = torch.as_tensor(ary_state, dtype=torch.float32, device=self.device).unsqueeze(0)
             actions[t] = action
             logprobs[t] = logprob
             rewards[t] = reward
             dones[t] = done
 
-        self.last_state = state
+        self.last_state = state  # state.shape == (1, state_dim) for a single env.
 
         rewards *= self.reward_scale
         undones = 1.0 - dones.type(torch.float32)

--- a/elegantrl/agents/AgentSAC.py
+++ b/elegantrl/agents/AgentSAC.py
@@ -26,7 +26,7 @@ class AgentSAC(AgentBase):
             states, actions, rewards, undones = buffer.add_item
             self.update_avg_std_for_normalization(
                 states=states.reshape((-1, self.state_dim)),
-                returns=self.get_returns(rewards=rewards, undones=undones).reshape((-1,))
+                returns=self.get_cumulative_rewards(rewards=rewards, undones=undones).reshape((-1,))
             )
 
         '''update network'''
@@ -63,32 +63,32 @@ class AgentSAC(AgentBase):
 
     def get_obj_critic_raw(self, buffer, batch_size: int) -> Tuple[Tensor, Tensor]:
         with torch.no_grad():
-            state, action, reward, undone, next_s = buffer.sample(batch_size)
-            next_a, next_logprob = self.act.get_action_logprob(next_s)  # stochastic policy
-            next_q = self.cri_target.get_q_min(next_s, next_a)  # twin critics
+            states, actions, rewards, undones, next_ss = buffer.sample(batch_size)  # next_ss: next states
+            next_as, next_logprobs = self.act.get_action_logprob(next_ss)  # next actions
+            next_qs = self.cri_target.get_q_min(next_ss, next_as)  # next q values
 
             alpha = self.alpha_log.exp().detach()
-            q_label = reward + undone * self.gamma * (next_q - next_logprob * alpha)
+            q_labels = rewards + undones * self.gamma * (next_qs - next_logprobs * alpha)
 
-        q1, q2 = self.cri.get_q1_q2(state, action)
-        obj_critic = self.criterion(q1, q_label) + self.criterion(q2, q_label)  # twin critics
-        return obj_critic, state
+        q1, q2 = self.cri.get_q1_q2(states, actions)
+        obj_critic = self.criterion(q1, q_labels) + self.criterion(q2, q_labels)  # twin critics
+        return obj_critic, states
 
     def get_obj_critic_per(self, buffer: ReplayBuffer, batch_size: int) -> Tuple[Tensor, Tensor]:
         with torch.no_grad():
-            state, action, reward, undone, next_s, is_weight, is_indices = buffer.sample_for_per(batch_size)
-            next_a, next_logprob = self.act.get_action_logprob(next_s)  # stochastic policy
-            next_q = self.cri_target.get_q_min(next_s, next_a)  # twin critics
+            states, actions, rewards, undones, next_ss, is_weights, is_indices = buffer.sample_for_per(batch_size)
+            next_as, next_logprobs = self.act.get_action_logprob(next_ss)
+            next_qs = self.cri_target.get_q_min(next_ss, next_as)
 
             alpha = self.alpha_log.exp().detach()
-            q_label = reward + undone * self.gamma * (next_q - next_logprob * alpha)
+            q_labels = rewards + undones * self.gamma * (next_qs - next_logprobs * alpha)
 
-        q1, q2 = self.cri.get_q1_q2(state, action)
-        td_error = self.criterion(q1, q_label) + self.criterion(q2, q_label)
-        obj_critic = (td_error * is_weight).mean()
+        q1, q2 = self.cri.get_q1_q2(states, actions)
+        td_errors = self.criterion(q1, q_labels) + self.criterion(q2, q_labels)
+        obj_critic = (td_errors * is_weights).mean()
 
-        buffer.td_error_update_for_per(is_indices.detach(), td_error.detach())
-        return obj_critic, state
+        buffer.td_error_update_for_per(is_indices.detach(), td_errors.detach())
+        return obj_critic, states
 
 
 class AgentModSAC(AgentSAC):  # Modified SAC using reliable_lambda and Two Time-scale Update Rule
@@ -102,7 +102,7 @@ class AgentModSAC(AgentSAC):  # Modified SAC using reliable_lambda and Two Time-
             states, actions, rewards, undones = buffer.add_item
             self.update_avg_std_for_normalization(
                 states=states.reshape((-1, self.state_dim)),
-                returns=self.get_returns(rewards=rewards, undones=undones).reshape((-1,))
+                returns=self.get_cumulative_rewards(rewards=rewards, undones=undones).reshape((-1,))
             )
 
         '''update network'''

--- a/elegantrl/agents/AgentTD3.py
+++ b/elegantrl/agents/AgentTD3.py
@@ -68,7 +68,7 @@ class AgentTD3(AgentBase):
 
     def get_obj_critic_per(self, buffer: ReplayBuffer, batch_size: int) -> Tuple[Tensor, Tensor]:
         with torch.no_grad():
-            state, action, reward, undone, next_s, is_weight = buffer.sample(batch_size)
+            state, action, reward, undone, next_s, is_weight, is_indices = buffer.sample_for_per(batch_size)
             next_a = self.act_target.get_action_noise(next_s, self.policy_noise_std)  # policy noise
             next_q = self.cri_target.get_q_min(next_s, next_a)  # twin critics
             q_label = reward + undone * self.gamma * next_q
@@ -77,5 +77,5 @@ class AgentTD3(AgentBase):
         td_error = self.criterion(q1, q_label) + self.criterion(q2, q_label)
         obj_critic = (td_error * is_weight).mean()
 
-        buffer.td_error_update(td_error.detach())
+        buffer.td_error_update_for_per(is_indices.detach(), td_error.detach())
         return obj_critic, state

--- a/elegantrl/agents/AgentTD3.py
+++ b/elegantrl/agents/AgentTD3.py
@@ -32,7 +32,7 @@ class AgentTD3(AgentBase):
             states, actions, rewards, undones = buffer.add_item
             self.update_avg_std_for_normalization(
                 states=states.reshape((-1, self.state_dim)),
-                returns=self.get_returns(rewards=rewards, undones=undones).reshape((-1,))
+                returns=self.get_cumulative_rewards(rewards=rewards, undones=undones).reshape((-1,))
             )
 
         '''update network'''
@@ -57,25 +57,27 @@ class AgentTD3(AgentBase):
 
     def get_obj_critic_raw(self, buffer: ReplayBuffer, batch_size: int) -> Tuple[Tensor, Tensor]:
         with torch.no_grad():
-            state, action, reward, undone, next_s = buffer.sample(batch_size)
-            next_a = self.act_target.get_action_noise(next_s, self.policy_noise_std)  # policy noise
-            next_q = self.cri_target.get_q_min(next_s, next_a)  # twin critics
-            q_label = reward + undone * self.gamma * next_q
+            states, actions, rewards, undones, next_ss = buffer.sample(batch_size)  # next_ss: next states
+            next_as = self.act_target.get_action_noise(next_ss, self.policy_noise_std)  # next actions
+            next_qs = self.cri_target.get_q_min(next_ss, next_as)  # next q values
+            q_labels = rewards + undones * self.gamma * next_qs
 
-        q1, q2 = self.cri.get_q1_q2(state, action)
-        obj_critic = self.criterion(q1, q_label) + self.criterion(q2, q_label)  # twin critics
-        return obj_critic, state
+        q1, q2 = self.cri.get_q1_q2(states, actions)
+        obj_critic = self.criterion(q1, q_labels) + self.criterion(q2, q_labels)  # twin critics
+        return obj_critic, states
 
     def get_obj_critic_per(self, buffer: ReplayBuffer, batch_size: int) -> Tuple[Tensor, Tensor]:
         with torch.no_grad():
-            state, action, reward, undone, next_s, is_weight, is_indices = buffer.sample_for_per(batch_size)
-            next_a = self.act_target.get_action_noise(next_s, self.policy_noise_std)  # policy noise
-            next_q = self.cri_target.get_q_min(next_s, next_a)  # twin critics
-            q_label = reward + undone * self.gamma * next_q
+            states, actions, rewards, undones, next_ss, is_weights, is_indices = buffer.sample_for_per(batch_size)
+            # is_weights, is_indices: important sampling `weights, indices` by Prioritized Experience Replay (PER)
 
-        q1, q2 = self.cri.get_q1_q2(state, action)
-        td_error = self.criterion(q1, q_label) + self.criterion(q2, q_label)
-        obj_critic = (td_error * is_weight).mean()
+            next_as = self.act_target.get_action_noise(next_ss, self.policy_noise_std)
+            next_qs = self.cri_target.get_q_min(next_ss, next_as)
+            q_labels = rewards + undones * self.gamma * next_qs
 
-        buffer.td_error_update_for_per(is_indices.detach(), td_error.detach())
-        return obj_critic, state
+        q1, q2 = self.cri.get_q1_q2(states, actions)
+        td_errors = self.criterion(q1, q_labels) + self.criterion(q2, q_labels)
+        obj_critic = (td_errors * is_weights).mean()
+
+        buffer.td_error_update_for_per(is_indices.detach(), td_errors.detach())
+        return obj_critic, states

--- a/elegantrl/agents/net.py
+++ b/elegantrl/agents/net.py
@@ -246,7 +246,7 @@ class ActorSAC(ActorBase):
         action_tanh = action.tanh()
         logprob = dist.log_prob(a_avg)
         logprob -= (-action_tanh.pow(2) + 1.000001).log()  # fix logprob using the derivative of action.tanh()
-        return action_tanh, logprob.sum(1, keepdim=True)
+        return action_tanh, logprob.sum(1)
 
 
 class ActorFixSAC(ActorSAC):
@@ -265,7 +265,7 @@ class ActorFixSAC(ActorSAC):
 
         logprob = dist.log_prob(a_avg)
         logprob -= 2 * (math.log(2) - action - self.soft_plus(action * -2))  # fix logprob using SoftPlus
-        return action.tanh(), logprob.sum(1, keepdim=True)
+        return action.tanh(), logprob.sum(1)
 
 
 class ActorPPO(ActorBase):

--- a/elegantrl/envs/CustomGymEnv.py
+++ b/elegantrl/envs/CustomGymEnv.py
@@ -9,15 +9,13 @@ Tensor = torch.Tensor
 
 InstallGymBox2D = """Install gym[Box2D]
 # LinuxOS (Ubuntu) 
-sudo apt install swig
+sudo apt update && sudo apt install swig
 python3 -m pip install --upgrade pip --no-warn-script-location
-pip3 install -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com --user gym==0.23.1
-pip3 install -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com --user gym[Box2D] 
+pip3 install -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com --user gym==0.23.1 gym[Box2D]
 
 # WindowOS (Windows NT)
 python -m pip install --upgrade pip
-pip3 install -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com gym==0.23.1
-pip3 install -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com swig gym[Box2D] 
+pip3 install -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com swig gym==0.23.1 gym[Box2D] 
 """
 
 
@@ -45,6 +43,8 @@ class PendulumEnv:  # a demo of custom gym env
         state, reward, done, info_dict = self.env.step(action * 2)
         return state, reward, done, info_dict
 
+    def render(self):
+        self.env.render()
 
 class GymNormaEnv(gym.Wrapper):
     def __init__(self, env_name: str = 'Hopper-v3'):

--- a/elegantrl/train/evaluator.py
+++ b/elegantrl/train/evaluator.py
@@ -6,8 +6,6 @@ from torch import Tensor
 
 from elegantrl.train.config import Config
 
-'''[ElegantRL.2022.12.12](github.com/AI4Fiance-Foundation/ElegantRL)'''
-
 
 class Evaluator:
     def __init__(self, cwd: str, env, args: Config, if_tensorboard: bool = False):
@@ -306,7 +304,7 @@ def draw_learning_curve(recorder: np.ndarray = None,
 
 def demo_evaluator_actor_pth():
     import gym
-    from elegantrl.agents.ppo import AgentPPO
+    from elegantrl.agents.AgentPPO import AgentPPO
     from elegantrl.train.config import Config, build_env
 
     gpu_id = 0  # >=0 means GPU ID, -1 means CPU
@@ -393,7 +391,7 @@ def demo_evaluate_actors(dir_path: str, gpu_id: int, agent, env_args: dict, eval
 
 def demo_load_pendulum_and_render():
     import torch
-    from elegantrl.agents.ppo import AgentPPO
+    from elegantrl.agents.AgentPPO import AgentPPO
     from elegantrl.train.config import Config, build_env
 
     gpu_id = 0  # >=0 means GPU ID, -1 means CPU
@@ -454,7 +452,7 @@ def demo_load_pendulum_and_render():
 
 
 def run():
-    from elegantrl.agents.ppo import AgentPPO
+    from elegantrl.agents.AgentPPO import AgentPPO
     flag_id = 1  # int(sys.argv[1])
 
     gpu_id = [2, 3][flag_id]

--- a/elegantrl/train/run.py
+++ b/elegantrl/train/run.py
@@ -1,15 +1,15 @@
 import os
+import sys
 import time
 import torch
 import numpy as np
 import torch.multiprocessing as mp  # torch.multiprocessing extends multiprocessing of Python
-
+from copy import deepcopy
 from multiprocessing import Process, Pipe
+
 from elegantrl.train.config import Config, build_env
 from elegantrl.train.replay_buffer import ReplayBuffer
 from elegantrl.train.evaluator import Evaluator, get_rewards_and_steps
-
-'''[ElegantRL.2022.12.12](github.com/AI4Fiance-Foundation/ElegantRL)'''
 
 if os.name == 'nt':  # if is WindowOS (Windows NT)
     """Fix bug about Anaconda in WindowOS
@@ -47,11 +47,15 @@ def train_agent(args: Config):
 
     '''init buffer'''
     if args.if_off_policy:
-        buffer = ReplayBuffer(gpu_id=args.gpu_id,
-                              num_envs=args.num_envs,
-                              max_size=args.buffer_size,
-                              state_dim=args.state_dim,
-                              action_dim=1 if args.if_discrete else args.action_dim)
+        buffer = ReplayBuffer(
+            gpu_id=args.gpu_id,
+            num_envs=args.num_envs,
+            max_size=args.buffer_size,
+            state_dim=args.state_dim,
+            action_dim=1 if args.if_discrete else args.action_dim,
+            if_use_per=args.if_use_per,
+            args=args,
+        )
         buffer_items = agent.explore_env(env, args.horizon_len * args.eval_times, if_random=True)
         buffer.update(buffer_items)  # warm up for ReplayBuffer
     else:
@@ -68,11 +72,13 @@ def train_agent(args: Config):
     break_step = args.break_step
     horizon_len = args.horizon_len
     if_off_policy = args.if_off_policy
+    if_save_buffer = args.if_save_buffer
     del args
 
     if_train = True
     while if_train:
         buffer_items = agent.explore_env(env, horizon_len)
+
         exp_r = buffer_items[2].mean().item()
         if if_off_policy:
             buffer.update(buffer_items)
@@ -87,16 +93,20 @@ def train_agent(args: Config):
         if_train = (evaluator.total_step <= break_step) and (not os.path.exists(f"{cwd}/stop"))
 
     print(f'| UsedTime: {time.time() - evaluator.start_time:>7.0f} | SavedDir: {cwd}')
+
+    env.close()
     evaluator.save_training_curve_jpg()
     agent.save_or_load_agent(cwd, if_save=True)
-    buffer.save_or_load_history(cwd, if_save=True) if if_off_policy else None
+    if if_save_buffer and hasattr(buffer, 'save_or_load_history'):
+        buffer.save_or_load_history(cwd, if_save=True)
 
 
 def train_agent_multiprocessing(args: Config):
     args.init_before_training()
 
     """Don't set method='fork' when send tensor in GPU"""
-    mp.set_start_method(method='forkserver', force=True)  # method in {'spawn', 'forkserver'}
+    method = 'spawn' if os.name == 'nt' else 'forkserver'  # os.name == 'nt' means Windows NT operating system (WinOS)
+    mp.set_start_method(method=method, force=True)
 
     '''build the Pipe'''
     worker_pipes = [Pipe(duplex=False) for _ in range(args.num_workers)]  # receive, send
@@ -120,12 +130,11 @@ class Learner(Process):
         super().__init__()
         self.recv_pipe = learner_pipe[0]
         self.send_pipes = [worker_pipe[1] for worker_pipe in worker_pipes]
-        self.eval_pipe = evaluator_pipe[0]
+        self.eval_pipe = evaluator_pipe[1]
         self.args = args
 
     def run(self):
         args = self.args
-        worker_num = len(self.send_pipes)
         torch.set_grad_enabled(False)
 
         '''init agent'''
@@ -133,44 +142,66 @@ class Learner(Process):
         agent.save_or_load_agent(args.cwd, if_save=False)
 
         '''init buffer'''
+        num_buffers = args.num_envs * args.num_workers
         if args.if_off_policy:
-            buffer = ReplayBuffer(gpu_id=args.gpu_id,
-                                  num_envs=args.num_envs * args.num_workers,
-                                  max_size=args.buffer_size,
-                                  state_dim=args.state_dim,
-                                  action_dim=1 if args.if_discrete else args.action_dim)
+            buffer = ReplayBuffer(
+                gpu_id=args.gpu_id,
+                num_envs=num_buffers,
+                max_size=args.buffer_size,
+                state_dim=args.state_dim,
+                action_dim=1 if args.if_discrete else args.action_dim,
+                if_use_per=args.if_use_per,
+                args=args,
+            )
         else:
             buffer = []
 
         '''loop'''
         if_off_policy = args.if_off_policy
         if_save_buffer = args.if_save_buffer
+        horizon_len = args.horizon_len
+        num_workers = args.num_workers
+        assert num_workers == len(self.send_pipes)
+        num_envs = args.num_envs
+        state_dim = args.state_dim
+        action_dim = args.action_dim
         steps = args.horizon_len * args.num_workers
         cwd = args.cwd
         del args
 
+        agent.last_state = torch.empty((num_buffers, state_dim), dtype=torch.float32, device=agent.device)
+
+        states = torch.empty((horizon_len, num_buffers, state_dim), dtype=torch.float32, device=agent.device)
+        actions = torch.empty((horizon_len, num_buffers, action_dim), dtype=torch.float32, device=agent.device)
+        rewards = torch.empty((horizon_len, num_buffers), dtype=torch.float32, device=agent.device)
+        undones = torch.empty((horizon_len, num_buffers), dtype=torch.bool, device=agent.device)
+        if if_off_policy:
+            buffer_items_tensor = (states, actions, rewards, undones)
+        else:
+            logprobs = torch.empty((horizon_len, num_buffers, action_dim), dtype=torch.float32, device=agent.device)
+            buffer_items_tensor = (states, actions, logprobs, rewards, undones)
+
         if_train = True
-        buffer_items_list = [[] for _ in range(worker_num)]
-        last_state_list = [torch.zeros(1) for _ in range(worker_num)]
         while if_train:
             '''Learner send actor to Workers'''
             for send_pipe in self.send_pipes:
                 send_pipe.send(agent.act)
 
             '''Learner receive (buffer_items, last_state) from Workers'''
-            for _ in range(worker_num):
+            for _ in range(num_workers):
                 worker_id, buffer_items, last_state = self.recv_pipe.recv()
 
-                buffer_items_list[worker_id] = buffer_items
-                last_state_list[worker_id] = last_state
+                buf_i = worker_id * num_envs
+                buf_j = worker_id * num_envs + num_envs
+                for buffer_item, buffer_tensor in zip(buffer_items, buffer_items_tensor):
+                    buffer_tensor[:, buf_i:buf_j] = buffer_item
+                agent.last_state[buf_i:buf_j] = last_state
 
             '''Learner update training data to (buffer, agent)'''
-            buffer_items_tensor = [torch.cat(tensors, dim=1) for tensors in zip(*buffer_items_list)]
             if if_off_policy:
                 buffer.update(buffer_items_tensor)
             else:
                 buffer[:] = buffer_items_tensor
-            agent.last_state = torch.cat(last_state_list, dim=0)
 
             '''agent update network using training data'''
             torch.set_grad_enabled(True)
@@ -183,6 +214,7 @@ class Learner(Process):
                 actor = agent.act  # so Leaner send an actor to evaluator for evaluation.
             else:
                 actor = None
+
             '''Learner send actor and training log to Evaluator'''
             exp_r = buffer_items_tensor[2].mean().item()  # the average rewards of exploration
             self.eval_pipe.send((actor, steps, exp_r, logging_tuple))
@@ -282,7 +314,7 @@ class EvaluatorProc(Process):
         '''loop'''
         cwd = args.cwd
         break_step = args.break_step
-        device = torch.device(f"cuda:{args.gpu_id}")
+        device = torch.device(f"cuda:{args.gpu_id}" if (torch.cuda.is_available() and (args.gpu_id >= 0)) else "cpu")
         del args
 
         if_train = True
@@ -304,7 +336,7 @@ class EvaluatorProc(Process):
 
         '''Evaluator save the training log and draw the learning curve'''
         evaluator.save_training_curve_jpg()
-        print(f'| TrainingTime: {time.time() - evaluator.start_time:>7.0f} | SavedDir: {cwd}')
+        print(f'| UsedTime: {time.time() - evaluator.start_time:>7.0f} | SavedDir: {cwd}')
 
         eval_env.close() if hasattr(eval_env, 'close') else None
 

--- a/elegantrl/train/run.py
+++ b/elegantrl/train/run.py
@@ -9,7 +9,7 @@ from multiprocessing import Process, Pipe
 
 from elegantrl.train.config import Config, build_env
 from elegantrl.train.replay_buffer import ReplayBuffer
-from elegantrl.train.evaluator import Evaluator, get_rewards_and_steps
+from elegantrl.train.evaluator import Evaluator, get_cumulative_rewards_and_steps
 
 if os.name == 'nt':  # if is WindowOS (Windows NT)
     """Fix bug about Anaconda in WindowOS
@@ -356,5 +356,5 @@ def render_agent(env_class, env_args: dict, net_dims: [int], agent_class, actor_
     print(f"| render and load actor from: {actor_path}")
     actor.load_state_dict(torch.load(actor_path, map_location=lambda storage, loc: storage))
     for i in range(render_times):
-        cumulative_reward, episode_step = get_rewards_and_steps(env, actor, if_render=True)
+        cumulative_reward, episode_step = get_cumulative_rewards_and_steps(env, actor, if_render=True)
         print(f"|{i:4}  cumulative_reward {cumulative_reward:9.3f}  episode_step {episode_step:5.0f}")

--- a/examples/demo_A2C_PPO.py
+++ b/examples/demo_A2C_PPO.py
@@ -683,8 +683,8 @@ def demo_load_pendulum_and_render():
 
     '''evaluate'''
     eval_times = 2 ** 7
-    from elegantrl.train.evaluator import get_rewards_and_steps
-    rewards_step_list = [get_rewards_and_steps(env, act) for _ in range(eval_times)]
+    from elegantrl.train.evaluator import get_cumulative_rewards_and_steps
+    rewards_step_list = [get_cumulative_rewards_and_steps(env, act) for _ in range(eval_times)]
     rewards_step_ten = torch.tensor(rewards_step_list)
     print(f"\n| average cumulative_returns {rewards_step_ten[:, 0].mean().item():9.3f}"
           f"\n| average      episode steps {rewards_step_ten[:, 1].mean().item():9.3f}")
@@ -740,9 +740,9 @@ def demo_load_pendulum_vectorized_env():
 
     '''evaluate'''
     eval_times = 2 ** 7
-    from elegantrl.train.evaluator import get_rewards_and_step_from_vec_env
+    from elegantrl.train.evaluator import get_cumulative_rewards_and_step_from_vec_env
     rewards_step_list = []
-    [rewards_step_list.extend(get_rewards_and_step_from_vec_env(env, act)) for _ in range(eval_times // num_envs)]
+    [rewards_step_list.extend(get_cumulative_rewards_and_step_from_vec_env(env, act)) for _ in range(eval_times // num_envs)]
     rewards_step_ten = torch.tensor(rewards_step_list)
     print(f"\n| average cumulative_returns {rewards_step_ten[:, 0].mean().item():9.3f}"
           f"\n| average      episode steps {rewards_step_ten[:, 1].mean().item():9.3f}")

--- a/examples/demo_DDPG_TD3_SAC.py
+++ b/examples/demo_DDPG_TD3_SAC.py
@@ -5,14 +5,14 @@ sys.path.append("..")
 if True:  # write after `sys.path.append("..")`
     from elegantrl import train_agent, train_agent_multiprocessing
     from elegantrl import Config, get_gym_env_args
-    from elegantrl.agents import AgentTD3
+    from elegantrl.agents import AgentDDPG, AgentTD3
     from elegantrl.agents import AgentSAC, AgentModSAC
 
 
-def train_ddpg_for_pendulum():
+def train_ddpg_td3_sac_for_pendulum():
     from elegantrl.envs.CustomGymEnv import PendulumEnv
 
-    agent_class = [AgentTD3, AgentSAC, AgentModSAC][DRL_ID]  # DRL algorithm name
+    agent_class = [AgentDDPG, AgentTD3, AgentSAC, AgentModSAC][DRL_ID]  # DRL algorithm name
     env_class = PendulumEnv  # run a custom env: PendulumEnv, which based on OpenAI pendulum
     env_args = {
         'env_name': 'Pendulum',  # Apply torque on the free end to swing a pendulum into an upright position
@@ -44,6 +44,13 @@ def train_ddpg_for_pendulum():
 -2000 < -1200 < -200 < -80
 ################################################################################
 ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
+0  3.20e+03       4 |-1463.02   44.1    200     0 |   -7.02   2.31 -21.30
+0  2.40e+04      34 |-1049.32   21.9    200     0 |   -7.57   1.80-103.58
+0  4.48e+04      61 | -163.25   62.2    200     0 |   -2.42   1.36-103.66
+0  6.56e+04      88 | -199.53  126.3    200     0 |   -0.96   1.40 -71.96
+| UsedTime:     110 | SavedDir: ./Pendulum_DDPG_0
+################################################################################
+ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
 0  4.00e+02       1 |-1211.60    4.7    200     0 |   -8.24   7.17  -5.75
 0  2.04e+04      58 | -207.35  138.9    200     0 |   -0.91   2.25 -45.49
 0  4.04e+04     117 |  -85.54   71.5    200     0 |   -0.95   1.04 -17.13
@@ -51,10 +58,10 @@ ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
     """
 
 
-def train_ddpg_for_pendulum_vec_env():
+def train_ddpg_td3_sac_for_pendulum_vec_env():
     from elegantrl.envs.CustomGymEnv import PendulumEnv
 
-    agent_class = [AgentTD3, AgentSAC, AgentModSAC][DRL_ID]  # DRL algorithm name
+    agent_class = [AgentTD3, AgentSAC, AgentModSAC, AgentDDPG][DRL_ID]  # DRL algorithm name
     env_class = PendulumEnv  # run a custom env: PendulumEnv, which based on OpenAI pendulum
     env_args = {
         'env_name': 'Pendulum',  # Apply torque on the free end to swing a pendulum into an upright position
@@ -69,20 +76,21 @@ def train_ddpg_for_pendulum_vec_env():
     get_gym_env_args(env=PendulumEnv(), if_print=True)  # return env_args
 
     args = Config(agent_class, env_class, env_args)  # see `config.py Arguments()` for hyperparameter explanation
-    args.break_step = int(2e4)  # break training if 'total_step > break_step'
-    # args.net_dims = (128, 64)  # the middle layer dimension of MultiLayer Perceptron
+    args.net_dims = (128, 64)  # the middle layer dimension of MultiLayer Perceptron
     args.batch_size = 512  # vectorized env need a larger batch_size
     args.gamma = 0.97  # discount factor of future rewards
     args.horizon_len = args.max_step
 
     args.repeat_times = 1.0  # repeatedly update network using ReplayBuffer to keep critic's loss small
-    args.learning_rate = 1e-4
+    args.learning_rate = 2e-4
     args.state_value_tau = 0.2  # the tau of normalize for value and state `std = (1-std)*std + tau*std`
 
-    args.gpu_id = GPU_ID
     args.eval_per_step = int(4e3)
+    args.break_step = int(1e4)  # break training if 'total_step > break_step'
+
+    args.gpu_id = GPU_ID
     args.num_workers = 4
-    if_single_process = False
+    if_single_process = True
     if if_single_process:
         train_agent(args)
     else:
@@ -91,17 +99,117 @@ def train_ddpg_for_pendulum_vec_env():
 -2000 < -1200 < -200 < -80
 ################################################################################
 ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
-1  1.60e+03      10 |-1444.53  275.0    200     0 |   -6.58   5.49 -18.76
-1  2.16e+04      64 | -200.44  115.7    200     0 |   -1.18   1.87 -47.91
-1  4.16e+04     120 | -153.00   84.5    200     0 |   -0.75   0.92 -18.70
-| UsedTime:     120 | SavedDir: ./Pendulum_TD3_0
+0  2.00e+02       7 |-1044.31    0.0    200     0 |   -7.03  19.73  -6.14
+0  4.20e+03      46 | -143.11    0.0    200     0 |   -2.82   2.59 -47.02
+0  8.20e+03      85 | -132.30    0.0    200     0 |   -1.73   3.48 -34.18
+| UsedTime:     105 | SavedDir: ./Pendulum_TD3_0
 ################################################################################
 ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
-1  1.60e+03      10 |-1387.47  167.9    200     0 |   -6.46   5.67 -28.75   0.33
-1  5.60e+03      17 |-1513.77   83.9    200     0 |   -5.79   0.72 -62.95   0.27
-1  9.60e+03      26 |-1054.83   41.8    200     0 |   -5.73   0.61 -79.48   0.23
-1  1.36e+04      35 | -734.88   81.0    200     0 |   -4.38   0.82 -89.61   0.26
-1  1.76e+04      45 | -140.39   77.9    200     0 |   -2.53   1.21 -91.22   0.34
+3  2.00e+02       2 |-1229.57   81.1    200     0 |   -5.87   6.28  -9.39   0.34
+3  4.20e+03      42 | -194.66  136.3    200     0 |   -3.46   0.82 -91.20   0.36
+3  8.20e+03      83 |  -94.45   57.3    200     0 |   -0.62   0.67 -57.82   0.29
+| UsedTime:     102 | SavedDir: ./Pendulum_ModSAC_0
+    """
+
+
+def train_ddpg_td3_sac_for_lunar_lander_continuous():
+    import gym
+
+    agent_class = [AgentTD3, AgentSAC, AgentModSAC][DRL_ID]  # DRL algorithm name
+    env_class = gym.make  # run a custom env: PendulumEnv, which based on OpenAI pendulum
+    env_args = {'env_name': 'LunarLanderContinuous-v2',
+                'num_envs': 1,
+                'max_step': 1000,
+                'state_dim': 8,
+                'action_dim': 2,
+                'if_discrete': False}
+    get_gym_env_args(env=gym.make('LunarLanderContinuous-v2'), if_print=True)  # return env_args
+
+    args = Config(agent_class, env_class, env_args)  # see `config.py Arguments()` for hyperparameter explanation
+    args.net_dims = (256, 256, 128)  # the middle layer dimension of MultiLayer Perceptron
+    args.batch_size = 128
+    args.gamma = 0.99  # discount factor of future rewards
+    args.horizon_len = args.max_step // 2
+    args.repeat_times = 1  # repeatedly update network using ReplayBuffer to keep critic's loss small
+    args.reward_scale = 2 ** -1
+    args.learning_rate = 1e-4
+    args.state_value_tau = 0.1  # the tau of normalize for value and state `std = (1-std)*std + tau*std`
+
+    args.eval_times = 32
+    args.eval_per_step = int(4e4)
+    args.break_step = int(4e5)  # break training if 'total_step > break_step'
+
+    args.gpu_id = GPU_ID
+    args.num_workers = 4
+
+    train_agent_multiprocessing(args)  # train_agent(args)
+    """
+-1500 < -200 < 200 < 290
+################################################################################
+ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
+3  3.60e+04     155 |   55.10  115.1    669   378 |   -0.00   0.65   2.21   0.03
+3  7.60e+04     241 |  212.24   65.0    403   229 |    0.05   0.80  11.81   0.06
+3  1.16e+05     350 |   49.57   78.3    308   341 |    0.01   0.57  14.12   0.04
+3  1.56e+05     500 |   97.97  103.7    754   302 |    0.13   0.62  12.42   0.04
+3  1.96e+05     596 |  134.18  133.3    562   328 |    0.14   0.58  10.31   0.03
+3  2.36e+05     690 |  247.05   26.1    298    96 |    0.21   0.52   8.43   0.03
+3  2.76e+05     801 |  148.64  111.6    218   114 |    0.21   0.61   8.90   0.03
+3  3.16e+05     920 |  174.72  138.2    353   235 |    0.36   0.58   9.07   0.03
+3  3.56e+05    1031 |  210.69   89.8    329   234 |    0.27   0.61   8.85   0.03
+3  3.96e+05    1139 |  260.68   25.7    275    86 |    0.34   0.61   9.23   0.02
+| UsedTime:    1147 | SavedDir: ./LunarLanderContinuous-v2_ModSAC_0
+    """
+
+
+def train_ddpg_td3_sac_for_lunar_lander_continuous_vec_env():
+    import gym
+
+    agent_class = [AgentTD3, AgentSAC, AgentModSAC][DRL_ID]  # DRL algorithm name
+    env_class = gym.make  # run a custom env: PendulumEnv, which based on OpenAI pendulum
+    env_args = {
+        'env_name': 'LunarLanderContinuous-v2',
+        'max_step': 1000,
+        'state_dim': 8,
+        'action_dim': 2,
+        'if_discrete': False,
+
+        'num_envs': 4,  # the number of sub envs in vectorized env
+        'if_build_vec_env': True,
+    }
+    get_gym_env_args(env=gym.make('LunarLanderContinuous-v2'), if_print=True)  # return env_args
+
+    args = Config(agent_class, env_class, env_args)  # see `config.py Arguments()` for hyperparameter explanation
+    args.net_dims = (256, 256, 128)  # the middle layer dimension of MultiLayer Perceptron
+    args.batch_size = 1024
+    args.gamma = 0.99  # discount factor of future rewards
+    args.horizon_len = args.max_step // 4
+    args.repeat_times = 1  # repeatedly update network using ReplayBuffer to keep critic's loss small
+    args.reward_scale = 2 ** -1
+    args.learning_rate = 2e-4
+    args.state_value_tau = 0.2  # the tau of normalize for value and state `std = (1-std)*std + tau*std`
+
+    args.eval_times = 32
+    args.eval_per_step = 2e4
+    args.break_step = int(2e5)  # break training if 'total_step > break_step'
+
+    args.gpu_id = GPU_ID
+    args.num_workers = 4
+    train_agent_multiprocessing(args)  # train_agent(args)
+    """
+-1500 < -200 < 200 < 290
+################################################################################
+ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
+2  2.00e+03      47 | -168.82  115.1    635   361 |   -0.78   1.42  -4.94   0.28
+2  2.20e+04     106 |  -64.67   26.2   1000     0 |   -0.05   0.65  -2.20   0.04
+2  4.20e+04     166 |  -26.96   17.3    678   443 |   -0.03   0.52   2.57   0.04
+2  6.20e+04     229 |   74.15  117.1    421   380 |   -0.03   0.48   6.46   0.04
+2  8.20e+04     291 |  157.59  133.7    421   357 |   -0.00   0.47   8.84   0.04
+2  1.02e+05     349 |  216.84   88.3    369   279 |    0.17   0.47   9.58   0.03
+2  1.22e+05     402 |  167.54  115.0    219   143 |    0.17   0.57  11.03   0.04
+2  1.42e+05     466 |  241.06   60.2    299   141 |    0.25   0.54  11.62   0.03
+2  1.62e+05     527 |  257.67   39.7    243   108 |    0.21   0.49  11.09   0.02
+2  1.82e+05     598 |  242.47   56.4    441   252 |    0.54   0.57  10.63   0.02
+| UsedTime:     627 | SavedDir: ./LunarLanderContinuous-v2_ModSAC_0
     """
 
 
@@ -109,7 +217,7 @@ if __name__ == '__main__':
     Parser = ArgumentParser(description='ArgumentParser for ElegantRL')
     Parser.add_argument('--gpu', type=int, default=0, help='GPU device ID for training')
     Parser.add_argument('--drl', type=int, default=0, help='RL algorithms ID for training')
-    Parser.add_argument('--env', type=str, default='1', help='the environment ID for training')
+    Parser.add_argument('--env', type=str, default='0', help='the environment ID for training')
 
     Args = Parser.parse_args()
     GPU_ID = Args.gpu
@@ -117,8 +225,12 @@ if __name__ == '__main__':
     ENV_ID = Args.env
 
     if ENV_ID in {'0', 'pendulum'}:
-        train_ddpg_for_pendulum()
+        train_ddpg_td3_sac_for_pendulum()
     elif ENV_ID in {'1', 'pendulum_vec'}:
-        train_ddpg_for_pendulum_vec_env()
+        train_ddpg_td3_sac_for_pendulum_vec_env()
+    elif ENV_ID in {'2', 'lunar_lander_continuous'}:
+        train_ddpg_td3_sac_for_lunar_lander_continuous()
+    elif ENV_ID in {'3', 'lunar_lander_continuous_vec'}:
+        train_ddpg_td3_sac_for_lunar_lander_continuous_vec_env()
     else:
         print('ENV_ID not match')

--- a/examples/demo_PER_Prioritized Experience Replay.py
+++ b/examples/demo_PER_Prioritized Experience Replay.py
@@ -52,6 +52,7 @@ def train_ddpg_td3_sac_for_lunar_lander_continuous():
         train_agent_multiprocessing(args)  # train_agent(args)
 
     """
+-1500 < -200 < 200 < 290
 ################################################################################
 ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
 2  4.00e+03      73 |  -53.40  119.4    733   226 |   -0.90   1.21  -2.89   0.28
@@ -65,8 +66,6 @@ ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
 2  3.24e+05     902 |  179.12  119.1    512   316 |    0.13   0.60  11.21   0.02
 2  3.64e+05     993 |  250.26   21.2    351   170 |    0.41   0.56  10.92   0.02
 | UsedTime:    1082 | SavedDir: ./LunarLanderContinuous-v2_ModSAC_0
-
--1500 < -200 < 200 < 290
 ################################################################################
 ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
 3  4.00e+03      20 | -237.07   67.0    233   105 |   -0.71   1.37  -1.28

--- a/examples/demo_PER_Prioritized Experience Replay.py
+++ b/examples/demo_PER_Prioritized Experience Replay.py
@@ -1,0 +1,100 @@
+import sys
+from argparse import ArgumentParser
+
+sys.path.append("..")
+if True:  # write after `sys.path.append("..")`
+    from elegantrl import train_agent, train_agent_multiprocessing
+    from elegantrl import Config, get_gym_env_args
+    from elegantrl.agents import AgentDDPG, AgentTD3
+    from elegantrl.agents import AgentSAC, AgentModSAC
+
+
+def train_ddpg_td3_sac_for_lunar_lander_continuous():
+    import gym
+
+    agent_class = [AgentTD3, AgentSAC, AgentModSAC, AgentDDPG][DRL_ID]  # DRL algorithm name
+    env_class = gym.make  # run a custom env: PendulumEnv, which based on OpenAI pendulum
+    env_args = {'env_name': 'LunarLanderContinuous-v2',
+                'num_envs': 1,
+                'max_step': 1000,
+                'state_dim': 8,
+                'action_dim': 2,
+                'if_discrete': False}
+    get_gym_env_args(env=gym.make('LunarLanderContinuous-v2'), if_print=True)  # return env_args
+
+    args = Config(agent_class, env_class, env_args)  # see `config.py Arguments()` for hyperparameter explanation
+    args.net_dims = (256, 256, 128)  # the middle layer dimension of MultiLayer Perceptron
+    args.batch_size = 128
+    args.gamma = 0.99  # discount factor of future rewards
+    args.horizon_len = args.max_step // 2
+    # args.repeat_times = 1  # repeatedly update network using ReplayBuffer to keep critic's loss small
+    args.reward_scale = 2 ** -1
+    args.learning_rate = 1e-4
+    args.state_value_tau = 0.1  # the tau of normalize for value and state `std = (1-std)*std + tau*std`
+
+    args.eval_times = 32
+    args.eval_per_step = int(4e4)
+    args.break_step = int(4e5)  # break training if 'total_step > break_step'
+
+    args.gpu_id = GPU_ID
+    args.num_workers = 4
+
+    args.if_use_per = True
+    args.per_alpha = 0.6  # see elegantrl/train/replay_buffer.py self.per_alpha = getattr(args, 'per_alpha', 0.6)
+    args.per_beta = 0.4  # see elegantrl/train/replay_buffer.py self.per_beta = getattr(args, 'per_beta', 0.4)
+    args.buffer_size = int(4e5)  # PER can handle larger buffer_size
+    args.repeat_times = 0.5  # PER don't need a large repeat_times
+
+    if_single_process = False
+    if if_single_process:
+        train_agent(args)
+    else:
+        train_agent_multiprocessing(args)  # train_agent(args)
+
+    """
+################################################################################
+ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
+2  4.00e+03      73 |  -53.40  119.4    733   226 |   -0.90   1.21  -2.89   0.28
+2  4.40e+04     186 |   16.26  104.6    862   239 |    0.00   0.81   4.85   0.06
+2  8.40e+04     254 |  126.60  160.5    485   272 |    0.09   0.68   9.82   0.04
+2  1.24e+05     393 |  110.49   96.4    826   221 |   -0.03   0.71  11.30   0.03
+2  1.64e+05     472 |  141.29  146.3    561   271 |    0.08   0.52   9.66   0.04
+2  2.04e+05     572 |  151.07  124.5    364   302 |    0.12   0.55  10.28   0.03
+2  2.44e+05     668 |   55.92  104.6    149   110 |    0.01   0.53  11.39   0.03
+2  2.84e+05     798 |  207.54   94.2    484   254 |    0.09   0.55  12.60   0.03
+2  3.24e+05     902 |  179.12  119.1    512   316 |    0.13   0.60  11.21   0.02
+2  3.64e+05     993 |  250.26   21.2    351   170 |    0.41   0.56  10.92   0.02
+| UsedTime:    1082 | SavedDir: ./LunarLanderContinuous-v2_ModSAC_0
+
+-1500 < -200 < 200 < 290
+################################################################################
+ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
+3  4.00e+03      20 | -237.07   67.0    233   105 |   -0.71   1.37  -1.28
+3  4.40e+04      77 |  -22.37   41.1    137    52 |    0.09   1.60   6.54
+3  8.40e+04     140 | -235.39   99.6    165    42 |   -0.46   1.46  10.86
+3  1.24e+05     254 | -151.96   95.3    715   327 |   -0.21   1.98  12.80
+3  1.64e+05     344 |  -33.57   33.2    916   266 |   -0.02   1.49  13.89
+3  2.16e+05     425 |  -34.89   50.6    883   298 |    0.00   1.31  15.08
+3  2.56e+05     488 |  -44.32   41.3    857   281 |    0.04   1.30  15.90
+3  2.96e+05     549 |  -51.70   59.5    847   264 |   -0.03   1.05  16.05
+3  3.36e+05     624 |  -16.65   29.0    891   293 |   -0.02   0.88  14.85
+3  3.76e+05     682 |   -6.47   83.7    806   322 |    0.01   0.84  13.59
+| UsedTime:     683 | SavedDir: ./LunarLanderContinuous-v2_TD3_0    # need to fine-tune
+    """
+
+
+if __name__ == '__main__':
+    Parser = ArgumentParser(description='ArgumentParser for ElegantRL')
+    Parser.add_argument('--gpu', type=int, default=0, help='GPU device ID for training')
+    Parser.add_argument('--drl', type=int, default=0, help='RL algorithms ID for training')
+    Parser.add_argument('--env', type=str, default='0', help='the environment ID for training')
+
+    Args = Parser.parse_args()
+    GPU_ID = Args.gpu
+    DRL_ID = Args.drl
+    ENV_ID = Args.env
+
+    if ENV_ID in {'0', 'lunar_lander_continuous'}:
+        train_ddpg_td3_sac_for_lunar_lander_continuous()
+    else:
+        print('ENV_ID not match')

--- a/examples/demo_PER_prioritized_experience_replay.py
+++ b/examples/demo_PER_prioritized_experience_replay.py
@@ -52,7 +52,6 @@ def train_ddpg_td3_sac_for_lunar_lander_continuous():
         train_agent_multiprocessing(args)  # train_agent(args)
 
     """
--1500 < -200 < 200 < 290
 ################################################################################
 ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
 2  4.00e+03      73 |  -53.40  119.4    733   226 |   -0.90   1.21  -2.89   0.28
@@ -66,6 +65,8 @@ ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
 2  3.24e+05     902 |  179.12  119.1    512   316 |    0.13   0.60  11.21   0.02
 2  3.64e+05     993 |  250.26   21.2    351   170 |    0.41   0.56  10.92   0.02
 | UsedTime:    1082 | SavedDir: ./LunarLanderContinuous-v2_ModSAC_0
+
+-1500 < -200 < 200 < 290
 ################################################################################
 ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
 3  4.00e+03      20 | -237.07   67.0    233   105 |   -0.71   1.37  -1.28

--- a/examples/demo_PaperTradingEnv_PPO.py
+++ b/examples/demo_PaperTradingEnv_PPO.py
@@ -1,0 +1,95 @@
+"""
+https://github.com/AI4Finance-Foundation/FinRL-Meta/blob/master/examples/FinRL_PaperTrading_Demo.ipynb
+"""
+
+"""Part I"""
+
+API_KEY = "PKAVSDVA8AIK4YBOOL3S"
+API_SECRET = "U6TKEjt9C77Dw21ca8zVGUhsZxTUohaLYdmOrO3L"
+API_BASE_URL = 'https://paper-api.alpaca.markets'
+data_url = 'wss://data.alpaca.markets'
+
+from finrl.config_tickers import DOW_30_TICKER
+from finrl.config import INDICATORS
+from finrl.meta.env_stock_trading.env_stocktrading_np import StockTradingEnv
+from finrl.meta.env_stock_trading.env_stock_papertrading import AlpacaPaperTrading
+from finrl.meta.data_processor import DataProcessor
+from finrl.plot import backtest_stats, backtest_plot, get_daily_return, get_baseline
+
+import numpy as np
+import pandas as pd
+
+
+def train(
+        start_date,
+        end_date,
+        ticker_list,
+        data_source,
+        time_interval,
+        technical_indicator_list,
+        drl_lib,
+        env,
+        model_name,
+        if_vix=True,
+        **kwargs,
+):
+    # download data
+    dp = DataProcessor(data_source, **kwargs)
+    data = dp.download_data(ticker_list, start_date, end_date, time_interval)
+    data = dp.clean_data(data)
+    data = dp.add_technical_indicator(data, technical_indicator_list)
+    if if_vix:
+        data = dp.add_vix(data)
+    else:
+        data = dp.add_turbulence(data)
+    price_array, tech_array, turbulence_array = dp.df_to_array(data, if_vix)
+
+    np.save('price_array.npy', price_array)
+    np.save('tech_array.npy', tech_array)
+    np.save('turbulence_array.npy', turbulence_array)
+    print("| save in '.'")
+
+
+def run():
+    ticker_list = DOW_30_TICKER
+    env = StockTradingEnv
+    erl_params = {"learning_rate": 3e-6, "batch_size": 2048, "gamma": 0.985,
+                  "seed": 312, "net_dimension": [128, 64], "target_step": 5000, "eval_gap": 30,
+                  "eval_times": 1}
+
+    train(start_date='2022-08-25',
+          end_date='2022-08-31',
+          ticker_list=ticker_list,
+          data_source='alpaca',
+          time_interval='1Min',
+          technical_indicator_list=INDICATORS,
+          drl_lib='elegantrl',
+          env=env,
+          model_name='ppo',
+          if_vix=True,
+          API_KEY=API_KEY,
+          API_SECRET=API_SECRET,
+          API_BASE_URL=API_BASE_URL,
+          erl_params=erl_params,
+          cwd='./papertrading_erl',  # current_working_dir
+          break_step=1e5)
+
+
+if __name__ == '__main__':
+    run()
+
+
+"""
+(base) develop@rlsmartagent-dev:~/workspace/ElegantRL0101/examples$ pip install git+https://github.com/AI4Finance-Foundation/FinRL.git
+Defaulting to user installation because normal site-packages is not writeable
+Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple
+Collecting git+https://github.com/AI4Finance-Foundation/FinRL.git
+  Cloning https://github.com/AI4Finance-Foundation/FinRL.git to /tmp/pip-req-build-er0zbi_n
+  Running command git clone -q https://github.com/AI4Finance-Foundation/FinRL.git /tmp/pip-req-build-er0zbi_n
+
+
+
+  fatal: unable to access 'https://github.com/AI4Finance-Foundation/FinRL.git/': GnuTLS recv error (-110): The TLS connection was non-properly terminated.
+WARNING: Discarding git+https://github.com/AI4Finance-Foundation/FinRL.git. Command errored out with exit status 128: git clone -q https://github.com/AI4Finance-Foundation/FinRL.git /tmp/pip-req-build-er0zbi_n Check the logs for full command output.
+ERROR: Command errored out with exit status 128: git clone -q https://github.com/AI4Finance-Foundation/FinRL.git /tmp/pip-req-build-er0zbi_n Check the logs for full command output.
+"""

--- a/unit_tests/agents/test_agents.py
+++ b/unit_tests/agents/test_agents.py
@@ -140,6 +140,9 @@ def check_agent_dqn_style(batch_size=3, horizon_len=16, net_dims=(64, 32), gpu_i
             print(f"  if_random = {if_random}")
 
             buffer_items = agent.explore_env(env=env, horizon_len=horizon_len, if_random=if_random)
+            assert isinstance(agent.last_state, Tensor)
+            assert agent.last_state.shape == (num_envs, state_dim)
+
             _check_buffer_items_for_off_policy(
                 buffer_items=buffer_items, if_discrete=if_discrete,
                 horizon_len=horizon_len, num_envs=num_envs,
@@ -198,6 +201,9 @@ def check_agent_ddpg_style(batch_size=3, horizon_len=16, net_dims=(64, 32), gpu_
 
         if_random = False
         buffer_items = agent.explore_env(env=env, horizon_len=horizon_len, if_random=if_random)
+        assert isinstance(agent.last_state, Tensor)
+        assert agent.last_state.shape == (num_envs, state_dim)
+
         _check_buffer_items_for_off_policy(
             buffer_items=buffer_items, if_discrete=if_discrete,
             horizon_len=horizon_len, num_envs=num_envs,
@@ -244,6 +250,9 @@ def check_agent_ppo_style(batch_size=3, horizon_len=16, net_dims=(64, 32), gpu_i
 
         '''check for agent.explore_env'''
         buffer_items = agent.explore_env(env=env, horizon_len=horizon_len)
+        assert isinstance(agent.last_state, Tensor)
+        assert agent.last_state.shape == (num_envs, state_dim)
+
         _check_buffer_items_for_ppo_style(
             buffer_items=buffer_items, if_discrete=if_discrete,
             horizon_len=horizon_len, num_envs=num_envs,

--- a/unit_tests/train/test_evaluator.py
+++ b/unit_tests/train/test_evaluator.py
@@ -7,7 +7,7 @@ EnvArgsPendulum = {'env_name': 'Pendulum-v1', 'state_dim': 3, 'action_dim': 1, '
 
 def test_get_rewards_and_steps():
     print("\n| test_get_rewards_and_steps()")
-    from elegantrl.train.evaluator import get_rewards_and_steps
+    from elegantrl.train.evaluator import get_cumulative_rewards_and_steps
     from elegantrl.agents.net import Actor
 
     env = PendulumEnv()
@@ -19,14 +19,14 @@ def test_get_rewards_and_steps():
     actor = Actor(dims=[8, 8], state_dim=state_dim, action_dim=action_dim)
 
     if_render = False
-    rewards, steps = get_rewards_and_steps(env=env, actor=actor, if_render=if_render)
+    rewards, steps = get_cumulative_rewards_and_steps(env=env, actor=actor, if_render=if_render)
     assert isinstance(rewards, float)
     assert isinstance(steps, int)
 
     if os.name == 'nt':  # if the operating system is Windows NT
         if_render = True
         print("\"libpng warning: iCCP: cHRM chunk does not match sRGB\" → It doesn't matter to see this warning.")
-        rewards, steps = get_rewards_and_steps(env=env, actor=actor, if_render=if_render)
+        rewards, steps = get_cumulative_rewards_and_steps(env=env, actor=actor, if_render=if_render)
         assert isinstance(rewards, float)
         assert isinstance(steps, int)
 


### PR DESCRIPTION
https://github.com/AI4Finance-Foundation/ElegantRL/issues/268

We can run `unit_tests` and  `example/demo_PER_Prioritized Experience Replay.py` for checking.

The output is following:
SAC + PER `per_alpha = 0.6, per_beta = 0.4`
```
-1500 < -200 < 200 < 290
################################################################################
ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
2  4.00e+03      73 |  -53.40  119.4    733   226 |   -0.90   1.21  -2.89   0.28
2  4.40e+04     186 |   16.26  104.6    862   239 |    0.00   0.81   4.85   0.06
2  8.40e+04     254 |  126.60  160.5    485   272 |    0.09   0.68   9.82   0.04
2  1.24e+05     393 |  110.49   96.4    826   221 |   -0.03   0.71  11.30   0.03
2  1.64e+05     472 |  141.29  146.3    561   271 |    0.08   0.52   9.66   0.04
2  2.04e+05     572 |  151.07  124.5    364   302 |    0.12   0.55  10.28   0.03
2  2.44e+05     668 |   55.92  104.6    149   110 |    0.01   0.53  11.39   0.03
2  2.84e+05     798 |  207.54   94.2    484   254 |    0.09   0.55  12.60   0.03
2  3.24e+05     902 |  179.12  119.1    512   316 |    0.13   0.60  11.21   0.02
2  3.64e+05     993 |  250.26   21.2    351   170 |    0.41   0.56  10.92   0.02
| UsedTime:    1082 | SavedDir: ./LunarLanderContinuous-v2_ModSAC_0
```

TD3 + PER `per_alpha = 0.6, per_beta = 0.4`
```
################################################################################
ID     Step    Time |    avgR   stdR   avgS  stdS |    expR   objC   objA   etc.
3  4.00e+03      20 | -237.07   67.0    233   105 |   -0.71   1.37  -1.28
3  4.40e+04      77 |  -22.37   41.1    137    52 |    0.09   1.60   6.54
3  8.40e+04     140 | -235.39   99.6    165    42 |   -0.46   1.46  10.86
3  1.24e+05     254 | -151.96   95.3    715   327 |   -0.21   1.98  12.80
3  1.64e+05     344 |  -33.57   33.2    916   266 |   -0.02   1.49  13.89
3  2.16e+05     425 |  -34.89   50.6    883   298 |    0.00   1.31  15.08
3  2.56e+05     488 |  -44.32   41.3    857   281 |    0.04   1.30  15.90
3  2.96e+05     549 |  -51.70   59.5    847   264 |   -0.03   1.05  16.05
3  3.36e+05     624 |  -16.65   29.0    891   293 |   -0.02   0.88  14.85
3  3.76e+05     682 |   -6.47   83.7    806   322 |    0.01   0.84  13.59
| UsedTime:     683 | SavedDir: ./LunarLanderContinuous-v2_TD3_0    # need to fine-tune
```


---

To fix this bug, we change the following codes:

Agents folder.
- In AgentXXX.py, in single env and vectorized env mode, make `agent.last_state.shape == (num_envs, state_dim)` to keep the shape of this tensor consistent.
- In AgentXXX.py, update `agent.get_obj_critic_per( )` for all algorithms to adapt it to the PER algorithm updates.
- In net,.py, make `logprob.shape == (batch_size, )` after summing over the action_dim dimension
- In evaluator.py, update the import

train folder.
- In replay_buffer.py, updated PER's sumTree, and the ReplayBuffer that calls sumTree.
- In run.py, updated the multiprocess module to adapt to PER compatibility under WinOS.
- In config.py, updated PER related parameters. And adjusted agent.last_state setting for  `agent.last_state.shape == (num_envs, state_dim)` 

env folder.
- In CustomGymEnv, updated the installation code of the simulation environment for checking the PER algorithm.

example folder.
- Adjusted the off-policy algorithm demo by moving the code for `if_use_per=True` from `demo_DDPG_TD3_SAC.py` to `demo_PER_Prioritized Experience Replay.py`

unit_test folder.
- update the unit_test file corresponding. (for  `agent.last_state.shape == (num_envs, state_dim)` )