### PR TITLE
:bug: fix bug in run,.py of logprob shape

### DIFF
--- a/elegantrl/train/run.py
+++ b/elegantrl/train/run.py
@@ -177,7 +177,7 @@ class Learner(Process):
         if if_off_policy:
             buffer_items_tensor = (states, actions, rewards, undones)
         else:
-            logprobs = torch.empty((horizon_len, num_seqs, action_dim), dtype=torch.float32, device=agent.device)
+            logprobs = torch.empty((horizon_len, num_seqs), dtype=torch.float32, device=agent.device)
             buffer_items_tensor = (states, actions, logprobs, rewards, undones)
 
         if_train = True


### PR DESCRIPTION
Fix the bug about `logprob.shape`

`logprob = logprob.sum(dim=1)`. So the `logprob.shape=(horizon_len, num_seqs)` instead of `logprob.shape=(horizon_len, num_seqs, action_dim)` 