### PR TITLE
:bug:  fix bug in replaybuffer load

### DIFF
--- a/elegantrl/train/replay_buffer.py
+++ b/elegantrl/train/replay_buffer.py
@@ -193,6 +193,7 @@ class ReplayBuffer:  # for off-policy
                 max_sizes.append(max_size)
             assert all([max_size == max_sizes[0] for max_size in max_sizes])
             self.cur_size = max_sizes[0]
+            self.if_full = self.cur_size == self.max_size
 
 
 class SumTree:


### PR DESCRIPTION
I change only one line in ReplayBuffer.

```
            self.cur_size = max_sizes[0]
            self.if_full = self.cur_size == self.max_size   #  -----> add this line 
```

This line update the `self.if_full` after load the historical data from the disk.