### PR TITLE
:sparkles:  better pointer for ReplayBuffer

### DIFF
--- a/elegantrl/train/replay_buffer.py
+++ b/elegantrl/train/replay_buffer.py
@@ -192,7 +192,7 @@ class ReplayBuffer:  # for off-policy
                 item[:max_size] = buf_item
                 max_sizes.append(max_size)
             assert all([max_size == max_sizes[0] for max_size in max_sizes])
-            self.cur_size = max_sizes[0]
+            self.cur_size = self.p = max_sizes[0]
             self.if_full = self.cur_size == self.max_size
 
 


### PR DESCRIPTION

Reset the value of the pointer of ReplayBuffer after load the data from disk.

change only one line: `self.cur_size = max_sizes[0]` to `self.cur_size = self.p = max_sizes[0]` as ElegantRL_Solver do.

(the default value `self.p=0`)


