### PR TITLE
Added compatibility with Python 3.7

### DIFF
--- a/elegantrl/agents/AgentBase.py
+++ b/elegantrl/agents/AgentBase.py
@@ -1,3 +1,4 @@
+from typing import List
 from ..manage_python import TupleAlias
 import os
 import numpy as np

--- a/elegantrl/agents/AgentBase.py
+++ b/elegantrl/agents/AgentBase.py
@@ -1,4 +1,4 @@
-from ..utils import TupleAlias
+from ..manage_python import TupleAlias
 import os
 import numpy as np
 import torch as th

--- a/elegantrl/agents/AgentBase.py
+++ b/elegantrl/agents/AgentBase.py
@@ -1,3 +1,4 @@
+from ..utils import TupleAlias
 import os
 import numpy as np
 import torch as th
@@ -67,7 +68,7 @@ class AgentBase:
         """save and load"""
         self.save_attr_names = {'act', 'act_target', 'act_optimizer', 'cri', 'cri_target', 'cri_optimizer'}
 
-    def explore_env(self, env, horizon_len: int) -> tuple[TEN, TEN, TEN, TEN, TEN]:
+    def explore_env(self, env, horizon_len: int) -> TupleAlias[TEN, TEN, TEN, TEN, TEN]:
         if self.if_vec_env:
             return self._explore_vec_env(env=env, horizon_len=horizon_len)
         else:
@@ -76,7 +77,7 @@ class AgentBase:
     def explore_action(self, state: TEN) -> TEN:
         return self.act.get_action(state, action_std=self.explore_noise_std)
 
-    def _explore_one_env(self, env, horizon_len: int) -> tuple[TEN, TEN, TEN, TEN, TEN]:
+    def _explore_one_env(self, env, horizon_len: int) -> TupleAlias[TEN, TEN, TEN, TEN, TEN]:
         """
         Collect trajectories through the actor-environment interaction for a **single** environment instance.
 
@@ -127,7 +128,7 @@ class AgentBase:
         unmasks = th.logical_not(truncates).view((horizon_len, 1))
         return states, actions, rewards, undones, unmasks
 
-    def _explore_vec_env(self, env, horizon_len: int) -> tuple[TEN, TEN, TEN, TEN, TEN]:
+    def _explore_vec_env(self, env, horizon_len: int) -> TupleAlias[TEN, TEN, TEN, TEN, TEN]:
         """
         Collect trajectories through the actor-environment interaction for a **vectorized** environment instance.
 
@@ -169,7 +170,7 @@ class AgentBase:
         unmasks = th.logical_not(truncates)
         return states, actions, rewards, undones, unmasks
 
-    def update_net(self, buffer: Union[ReplayBuffer, tuple]) -> tuple[float, ...]:
+    def update_net(self, buffer: Union[ReplayBuffer, tuple]) -> TupleAlias[float, ...]:
         objs_critic = []
         objs_actor = []
 
@@ -188,7 +189,7 @@ class AgentBase:
         obj_avg_actor = np.nanmean(objs_actor) if len(objs_actor) else 0.0
         return obj_avg_critic, obj_avg_actor
 
-    def update_objectives(self, buffer: ReplayBuffer, update_t: int) -> tuple[float, float]:
+    def update_objectives(self, buffer: ReplayBuffer, update_t: int) -> TupleAlias[float, float]:
         assert isinstance(update_t, int)
         with th.no_grad():
             if self.if_use_per:

--- a/elegantrl/agents/AgentPPO.py
+++ b/elegantrl/agents/AgentPPO.py
@@ -1,3 +1,4 @@
+from ..utils import TupleAlias
 import numpy as np
 import torch as th
 from torch import nn
@@ -31,7 +32,7 @@ class AgentPPO(AgentBase):
 
         self.if_use_v_trace = getattr(args, 'if_use_v_trace', True)
 
-    def _explore_one_env(self, env, horizon_len: int, if_random: bool = False) -> tuple[TEN, TEN, TEN, TEN, TEN, TEN]:
+    def _explore_one_env(self, env, horizon_len: int, if_random: bool = False) -> TupleAlias[TEN, TEN, TEN, TEN, TEN, TEN]:
         """
         Collect trajectories through the actor-environment interaction for a **single** environment instance.
 
@@ -84,7 +85,7 @@ class AgentPPO(AgentBase):
         unmasks = th.logical_not(truncates).view((horizon_len, 1))
         return states, actions, logprobs, rewards, undones, unmasks
 
-    def _explore_vec_env(self, env, horizon_len: int, if_random: bool = False) -> tuple[TEN, TEN, TEN, TEN, TEN, TEN]:
+    def _explore_vec_env(self, env, horizon_len: int, if_random: bool = False) -> TupleAlias[TEN, TEN, TEN, TEN, TEN, TEN]:
         """
         Collect trajectories through the actor-environment interaction for a **vectorized** environment instance.
 
@@ -128,11 +129,11 @@ class AgentPPO(AgentBase):
         unmasks = th.logical_not(truncates)
         return states, actions, logprobs, rewards, undones, unmasks
 
-    def explore_action(self, state: TEN) -> tuple[TEN, TEN]:
+    def explore_action(self, state: TEN) -> TupleAlias[TEN, TEN]:
         actions, logprobs = self.act.get_action(state)
         return actions, logprobs
 
-    def update_net(self, buffer) -> tuple[float, float, float]:
+    def update_net(self, buffer) -> TupleAlias[float, float, float]:
         buffer_size = buffer[0].shape[0]
 
         '''get advantages reward_sums'''
@@ -170,7 +171,7 @@ class AgentPPO(AgentBase):
         obj_actor_avg = np.array(obj_actors).mean() if len(obj_actors) else 0.0
         return obj_critic_avg, obj_actor_avg, obj_entropy_avg
 
-    def update_objectives(self, buffer: tuple[TEN, ...], update_t: int) -> tuple[float, float, float]:
+    def update_objectives(self, buffer: TupleAlias[TEN, ...], update_t: int) -> TupleAlias[float, float, float]:
         states, actions, unmasks, logprobs, advantages, reward_sums = buffer
 
         sample_len = states.shape[0]
@@ -254,7 +255,7 @@ class AgentA2C(AgentPPO):
     “Asynchronous Methods for Deep Reinforcement Learning”. 2016.
     """
 
-    def update_net(self, buffer) -> tuple[float, float, float]:
+    def update_net(self, buffer) -> TupleAlias[float, float, float]:
         buffer_size = buffer[0].shape[0]
 
         '''get advantages reward_sums'''
@@ -289,7 +290,7 @@ class AgentA2C(AgentPPO):
         obj_actor_avg = np.array(obj_actors).mean() if len(obj_actors) else 0.0
         return obj_critic_avg, obj_actor_avg, 0
 
-    def update_objectives(self, buffer: tuple[TEN, ...], update_t: int) -> tuple[float, float]:
+    def update_objectives(self, buffer: TupleAlias[TEN, ...], update_t: int) -> TupleAlias[float, float]:
         states, actions, unmasks, logprobs, advantages, reward_sums = buffer
 
         buffer_size = states.shape[0]
@@ -365,7 +366,7 @@ class ActorPPO(th.nn.Module):
         action = self.net(state)
         return self.convert_action_for_env(action)
 
-    def get_action(self, state: TEN) -> tuple[TEN, TEN]:  # for exploration
+    def get_action(self, state: TEN) -> TupleAlias[TEN, TEN]:  # for exploration
         state = self.state_norm(state)
         action_avg = self.net(state)
         action_std = self.action_std_log.exp()
@@ -375,7 +376,7 @@ class ActorPPO(th.nn.Module):
         logprob = dist.log_prob(action).sum(1)
         return action, logprob
 
-    def get_logprob_entropy(self, state: TEN, action: TEN) -> tuple[TEN, TEN]:
+    def get_logprob_entropy(self, state: TEN, action: TEN) -> TupleAlias[TEN, TEN]:
         state = self.state_norm(state)
         action_avg = self.net(state)
         action_std = self.action_std_log.exp()

--- a/elegantrl/agents/AgentPPO.py
+++ b/elegantrl/agents/AgentPPO.py
@@ -1,3 +1,4 @@
+from typing import List
 from ..manage_python import TupleAlias
 import numpy as np
 import torch as th
@@ -347,7 +348,7 @@ class AgentDiscreteA2C(AgentDiscretePPO):
 
 
 class ActorPPO(th.nn.Module):
-    def __init__(self, net_dims: list[int], state_dim: int, action_dim: int):
+    def __init__(self, net_dims: List[int], state_dim: int, action_dim: int):
         super().__init__()
         self.net = build_mlp(dims=[state_dim, *net_dims, action_dim])
         layer_init_with_orthogonal(self.net[-1], std=0.1)
@@ -392,7 +393,7 @@ class ActorPPO(th.nn.Module):
 
 
 class ActorDiscretePPO(ActorPPO):
-    def __init__(self, net_dims: list[int], state_dim: int, action_dim: int):
+    def __init__(self, net_dims: List[int], state_dim: int, action_dim: int):
         super().__init__(net_dims=net_dims, state_dim=state_dim, action_dim=action_dim)
         self.ActionDist = th.distributions.Categorical
         self.soft_max = nn.Softmax(dim=-1)
@@ -424,7 +425,7 @@ class ActorDiscretePPO(ActorPPO):
 
 
 class CriticPPO(th.nn.Module):
-    def __init__(self, net_dims: list[int], state_dim: int, action_dim: int):
+    def __init__(self, net_dims: List[int], state_dim: int, action_dim: int):
         super().__init__()
         assert isinstance(action_dim, int)
         self.net = build_mlp(dims=[state_dim, *net_dims, 1])

--- a/elegantrl/agents/AgentPPO.py
+++ b/elegantrl/agents/AgentPPO.py
@@ -1,4 +1,4 @@
-from ..utils import TupleAlias
+from ..manage_python import TupleAlias
 import numpy as np
 import torch as th
 from torch import nn

--- a/elegantrl/envs/PointChasingEnv.py
+++ b/elegantrl/envs/PointChasingEnv.py
@@ -1,3 +1,4 @@
+from typing import List
 from typing import Tuple
 
 import numpy as np

--- a/elegantrl/manage_python.py
+++ b/elegantrl/manage_python.py
@@ -1,0 +1,5 @@
+import sys
+from typing import Tuple
+
+# Define TupleAlias in a separate module
+TupleAlias = tuple if sys.version_info >= (3, 9) else Tuple

--- a/elegantrl/train/config.py
+++ b/elegantrl/train/config.py
@@ -1,3 +1,4 @@
+from typing import List
 import os
 import torch as th
 import numpy as np

--- a/elegantrl/train/evaluator.py
+++ b/elegantrl/train/evaluator.py
@@ -1,3 +1,4 @@
+from ..utils import TupleAlias
 import os
 import time
 import numpy as np

--- a/elegantrl/train/evaluator.py
+++ b/elegantrl/train/evaluator.py
@@ -1,4 +1,4 @@
-from ..utils import TupleAlias
+from ..manage_python import TupleAlias
 import os
 import time
 import numpy as np


### PR DESCRIPTION
Here are few changes that ensure the compatibility with python3.7, they do not break the compatibility with the other versions :

- elegant/manage_python.py : creates an alias named TupleAlias that switches between 'Tuple' (for python3.7 and 3.8) and 'tuple' (python >= 3.9)
- the TupleAlias  variable replaces any  'tuple' in all files concerned (e.g. BaseAgent.py)
- the expression 'list' is replaced by the typing class List (which is compatible for any version of Python)